### PR TITLE
Add compiler plugin functionality to remove the dependency on reflection when getting supertype in `dataSourceWrapper`.

### DIFF
--- a/kronos-compiler-plugin/src/main/kotlin/com/kotlinorm/compiler/fir/transformer/KronosParserTransformer.kt
+++ b/kronos-compiler-plugin/src/main/kotlin/com/kotlinorm/compiler/fir/transformer/KronosParserTransformer.kt
@@ -38,6 +38,7 @@ import org.jetbrains.kotlin.ir.builders.irBlockBody
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.expressions.IrBlockBody
+import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.ir.expressions.IrClassReference
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
@@ -70,6 +71,19 @@ class KronosParserTransformer(
             KTABLE_FOR_REFERENCE_CLASS -> declaration.body = transformKTableForReference(declaration)
         }
         return super.visitFunctionNew(declaration)
+    }
+
+    override fun visitCall(expression: IrCall): IrExpression {
+        // com.kotlinorm.beans.task.KronosQueryTask.queryList
+        // com.kotlinorm.beans.task.KronosQueryTask.queryOne
+        // com.kotlinorm.beans.task.KronosQueryTask.queryOneOrNull
+        // com.kotlinorm.orm.select.SelectClause.queryList
+        // com.kotlinorm.orm.select.SelectClause.queryOne
+        // com.kotlinorm.orm.select.SelectClause.queryOneOrNull
+        // com.kotlinorm.orm.join.SelectFrom.queryList
+        // com.kotlinorm.orm.join.SelectFrom.queryOne
+        // com.kotlinorm.orm.join.SelectFrom.queryOneOrNull
+        return super.visitCall(expression)
     }
 
     /**

--- a/kronos-compiler-plugin/src/main/kotlin/com/kotlinorm/compiler/fir/transformer/KronosParserTransformer.kt
+++ b/kronos-compiler-plugin/src/main/kotlin/com/kotlinorm/compiler/fir/transformer/KronosParserTransformer.kt
@@ -74,6 +74,7 @@ class KronosParserTransformer(
     }
 
     override fun visitCall(expression: IrCall): IrExpression {
+        // SET PARAMETERS (IS_K_POJO AND SUPER_TYPES) FOR FOLLOWING CALLS:
         // com.kotlinorm.beans.task.KronosQueryTask.queryList
         // com.kotlinorm.beans.task.KronosQueryTask.queryOne
         // com.kotlinorm.beans.task.KronosQueryTask.queryOneOrNull

--- a/kronos-compiler-plugin/src/main/kotlin/com/kotlinorm/compiler/fir/utils/KClassCreatorUtil.kt
+++ b/kronos-compiler-plugin/src/main/kotlin/com/kotlinorm/compiler/fir/utils/KClassCreatorUtil.kt
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022-2024 kronos-orm
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.kotlinorm.compiler.fir.utils
 
 import com.kotlinorm.compiler.helpers.kFunctionN

--- a/kronos-compiler-plugin/src/main/kotlin/com/kotlinorm/compiler/fir/utils/KClassCreatorUtil.kt
+++ b/kronos-compiler-plugin/src/main/kotlin/com/kotlinorm/compiler/fir/utils/KClassCreatorUtil.kt
@@ -51,7 +51,7 @@ import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.typeWith
 import org.jetbrains.kotlin.ir.util.allParameters
-import org.jetbrains.kotlin.ir.util.classId
+import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
 import org.jetbrains.kotlin.ir.util.statements
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.FqName
@@ -111,7 +111,7 @@ object KClassCreatorUtil {
                         +irReturn(
                             irWhen(
                                 KPojoSymbol.nType,
-                                kPojoClasses.mapNotNull {
+                                kPojoClasses.distinctBy { it.fqNameWhenAvailable }.mapNotNull {
                                     createExprNew(it.symbol)?.let { new ->
                                         irBranch(
                                             irEquals(

--- a/kronos-compiler-plugin/src/main/kotlin/com/kotlinorm/compiler/fir/utils/KQueryTaskUtil.kt
+++ b/kronos-compiler-plugin/src/main/kotlin/com/kotlinorm/compiler/fir/utils/KQueryTaskUtil.kt
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2022-2024 kronos-orm
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.kotlinorm.compiler.fir.utils
+
+import com.kotlinorm.compiler.helpers.irListOf
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.ir.backend.js.utils.typeArguments
+import org.jetbrains.kotlin.ir.builders.IrBlockBuilder
+import org.jetbrains.kotlin.ir.builders.irBoolean
+import org.jetbrains.kotlin.ir.builders.irString
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.types.classFqName
+import org.jetbrains.kotlin.ir.util.superTypes
+import org.jetbrains.kotlin.name.FqName
+
+val fqNameOfTypedQuery =
+    listOf(
+        FqName("com.kotlinorm.beans.task.KronosQueryTask.queryList"),
+        FqName("com.kotlinorm.beans.task.KronosQueryTask.queryOne"),
+        FqName("com.kotlinorm.beans.task.KronosQueryTask.queryOneOrNull"),
+        FqName("com.kotlinorm.orm.select.SelectClause.queryList"),
+        FqName("com.kotlinorm.orm.select.SelectClause.queryOne"),
+        FqName("com.kotlinorm.orm.select.SelectClause.queryOneOrNull"),
+        FqName("com.kotlinorm.database.SqlHandler.queryList"),
+        FqName("com.kotlinorm.database.SqlHandler.queryOne"),
+        FqName("com.kotlinorm.database.SqlHandler.queryOneOrNull")
+    )
+
+val fqNameOfSelectFromsRegexes =
+    listOf(
+        "com.kotlinorm.orm.join.SelectFrom\\d.queryList",
+        "com.kotlinorm.orm.join.SelectFrom\\d.queryOne",
+        "com.kotlinorm.orm.join.SelectFrom\\d.queryOneOrNull"
+    )
+
+context(IrPluginContext, IrBlockBuilder)
+fun updateTypedQueryParameters(irCall: IrCall): IrCall {
+    val queryType = irCall.typeArguments.first()!!
+    val superTypes = (listOf(queryType) + queryType.superTypes()).map { it.classFqName!! }
+    val irSuperTypes = irListOf(
+        irBuiltIns.stringType,
+        superTypes.map { irString(it.asString()) }
+    )
+    val isKPojo = KPojoFqName in superTypes
+    // 请务必保证上方函数的最后两个参数为 isKPojo 和 superTypes
+    // 否则会导致 irCall 的参数顺序错乱
+    irCall.putValueArgument(irCall.valueArgumentsCount - 2, irBoolean(isKPojo))
+    irCall.putValueArgument(irCall.valueArgumentsCount - 1, irSuperTypes)
+    return irCall
+}

--- a/kronos-compiler-plugin/src/main/kotlin/com/kotlinorm/compiler/fir/utils/kTableForReference/KTableForReferenceUtil.kt
+++ b/kronos-compiler-plugin/src/main/kotlin/com/kotlinorm/compiler/fir/utils/kTableForReference/KTableForReferenceUtil.kt
@@ -54,7 +54,6 @@ fun addReferenceList(irReturn: IrReturn): List<IrExpression> {
  * @return a mutable list of IR expressions representing the field names
  */
 context(IrBuilderWithScope, IrPluginContext, IrFunction)
-@OptIn(UnsafeDuringIrConstructionAPI::class)
 fun collectReferences(
     element: IrElement
 ): MutableList<IrExpression> {

--- a/kronos-compiler-plugin/src/test/kotlin/com/kotlinorm/compiler/fir/transformer/kTable/KTableParserForConditionTransformerTest.kt
+++ b/kronos-compiler-plugin/src/test/kotlin/com/kotlinorm/compiler/fir/transformer/kTable/KTableParserForConditionTransformerTest.kt
@@ -290,6 +290,7 @@ class KTableParserForConditionTransformerTest {
                 )
     }
 
+    @Language("kotlin")
     private val mainKt = """
             import com.kotlinorm.Kronos
             import com.kotlinorm.annotations.*
@@ -425,7 +426,7 @@ class KTableParserForConditionTransformerTest {
 
     @OptIn(ExperimentalCompilerApi::class)
     infix fun String.testCompile(@Language("kotlin") code: String) {
-        if (this.any { !it.isLetter() } && this.first().isLowerCase()) {
+        if (this.any { !it.isLetter() } || this.first().isLowerCase()) {
             throw IllegalArgumentException("测试名称必须全部都是字母，且首字母必须大写")
         }
         val result = compile(mainKt.replace("//inject", code), this@KTableParserForConditionTransformerTest.testBaseName + this)

--- a/kronos-compiler-plugin/src/test/kotlin/com/kotlinorm/compiler/fir/utils/KQueryTaskTest.kt
+++ b/kronos-compiler-plugin/src/test/kotlin/com/kotlinorm/compiler/fir/utils/KQueryTaskTest.kt
@@ -1,0 +1,269 @@
+package com.kotlinorm.compiler.fir.utils
+
+import com.kotlinorm.compiler.fir.KotlinSourceDynamicCompiler.compile
+import com.kotlinorm.compiler.fir.testBaseName
+import com.tschuchort.compiletesting.KotlinCompilation
+import org.intellij.lang.annotations.Language
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class KQueryTaskTest {
+    @Test
+    fun `KronosQueryTask_queryOne Test`() {
+        "KronosQueryTaskQueryOne" testCompile
+         """
+            fun test(){
+                assertEquals(1, KronosQueryTask(
+                    KronosAtomicQueryTask(
+                        "SELECT id FROM user where id = 1"
+                    )
+                ).queryOne<Int>())
+            }
+        """
+    }
+    @Test
+    fun `KronosQueryTask_queryOneOrNull Test`() {
+        "KronosQueryTaskQueryOneOrNull" testCompile
+                """
+            fun test(){
+                assertEquals(1, KronosQueryTask(
+                    KronosAtomicQueryTask(
+                        "SELECT id FROM user where id = 1"
+                    )
+                ).queryOneOrNull<Int>())
+            }
+        """
+    }
+
+    @Test
+    fun `KronosQueryTask_queryList Test`() {
+        "KronosQueryTaskQueryList" testCompile """
+            fun test(){
+                assertEquals(listOf(1), KronosQueryTask(
+                    KronosAtomicQueryTask(
+                        "SELECT id FROM user"
+                    )
+                ).queryList<Int>())
+            }
+        """
+    }
+
+    @Test
+    fun `SelectClause_queryList Test`() {
+        "SelectClauseQueryList" testCompile
+                """
+            fun test(){
+                assertEquals(listOf(1), User(1).select().queryList<Int>())
+            }
+        """
+    }
+
+    @Test
+    fun `SelectClause_queryOne Test`() {
+        "SelectClauseQueryOne" testCompile
+                """
+            fun test(){
+                assertEquals(1, User(1).select().queryOne<Int>())
+            }
+        """
+    }
+
+    @Test
+    fun `SelectClause_queryOneOrNull Test`() {
+        "SelectClauseQueryOneOrNull" testCompile
+                """
+            fun test(){
+                assertEquals(1, User(1).select().queryOneOrNull<Int>())
+            }
+        """
+    }
+
+    @Test
+    fun `SelectFrom_queryOneOrNull Test`() {
+        "SelectFormQueryOneOrNull" testCompile
+                """
+            fun test(){
+                assertEquals(1, User().join(Email()){ user, email->
+                    select{ email.id }
+                    on { user.id == email.userId }
+                }.queryOneOrNull<Int>())
+            }
+        """
+    }
+
+    @Test
+    fun `SelectFrom_queryOne Test`() {
+        "SelectFormQueryOne" testCompile
+                """
+            fun test(){
+                assertEquals(1, User().join(Email()){ user, email->
+                    select{ email.id }
+                    on { user.id == email.userId }
+                }.queryOne<Int>())
+            }
+        """
+    }
+
+    @Test
+    fun `SelectFrom_queryList Test`() {
+        "SelectFormQueryList" testCompile
+                """
+            fun test(){
+                assertEquals(listOf(1), User().join(Email()){ user, email->
+                    select{ email.id }
+                    on { user.id == email.userId }
+                }.queryList<Int>())
+            }
+        """
+    }
+
+    @Test
+    fun `QueryHandler_queryList Test`() {
+        "QueryHandlerQueryList" testCompile
+                """
+            fun test(){
+                assertEquals(listOf(1), TestWrapper.queryList<Int>("select id from user where id = 1"))
+            }
+        """
+    }
+
+    @Test
+    fun `QueryHandler_queryOne Test`() {
+        "QueryHandlerQueryOne" testCompile
+                """
+            fun test(){
+                assertEquals(1, TestWrapper.queryOne<Int>("select id from user where id = 1"))
+            }
+        """
+    }
+
+    @Test
+    fun `QueryHandler_queryOneOrNull Test`() {
+        "QueryHandlerQueryOneOrNull" testCompile
+                """
+            fun test(){
+                assertEquals(1, TestWrapper.queryOneOrNull<Int>("select id from user where id = 1"))
+            }
+        """
+    }
+
+    @Language("kotlin")
+    private val mainKt = """
+            import com.kotlinorm.beans.task.KronosAtomicBatchTask
+            import com.kotlinorm.enums.DBType
+            import com.kotlinorm.interfaces.KAtomicActionTask
+            import com.kotlinorm.interfaces.KAtomicQueryTask
+            import com.kotlinorm.interfaces.KronosDataSourceWrapper
+            import javax.sql.DataSource
+            import kotlin.reflect.KClass
+
+            import com.kotlinorm.Kronos
+            import com.kotlinorm.Kronos.init
+            import com.kotlinorm.annotations.*
+            import com.kotlinorm.interfaces.KPojo
+            import com.kotlinorm.orm.select.select
+            import com.kotlinorm.orm.join.join
+            import com.kotlinorm.enums.KColumnType.TINYINT
+            import com.kotlinorm.utils.createInstance
+            import java.time.LocalDateTime
+            import kotlin.test.assertEquals
+            import kotlin.test.assertNotNull
+            import com.kotlinorm.enums.DBType.Mysql
+        
+            import com.kotlinorm.beans.task.KronosAtomicQueryTask
+            import com.kotlinorm.beans.task.KronosQueryTask
+
+            import com.kotlinorm.database.SqlHandler.queryList
+            import com.kotlinorm.database.SqlHandler.queryOne
+            import com.kotlinorm.database.SqlHandler.queryOneOrNull
+
+            object TestWrapper : KronosDataSourceWrapper {
+                override val url: String
+                    get() = TODO("Not yet implemented")
+                override val userName: String
+                    get() = TODO("Not yet implemented")
+                override val dbType: DBType
+                    get() = Mysql
+        
+                override fun forList(task: KAtomicQueryTask): List<Map<String, Any>> {
+                    TODO("Not yet implemented")
+                }
+        
+                override fun forList(
+                    task: KAtomicQueryTask,
+                    kClass: KClass<*>,
+                    isKPojo: Boolean,
+                    superTypes: List<String>
+                ): List<Any> {
+                    assertEquals(isKPojo, false)
+                    assertEquals(superTypes, listOf("kotlin.Int", "kotlin.Number", "kotlin.Comparable", "java.io.Serializable"))
+                    return listOf(1)
+                }
+        
+                override fun forMap(task: KAtomicQueryTask): Map<String, Any>? {
+                    TODO("Not yet implemented")
+                }
+        
+                override fun forObject(
+                    task: KAtomicQueryTask,
+                    kClass: KClass<*>,
+                    isKPojo: Boolean,
+                    superTypes: List<String>
+                ): Any? {
+                    assertEquals(isKPojo, false)
+                    assertEquals(superTypes, listOf("kotlin.Int", "kotlin.Number", "kotlin.Comparable", "java.io.Serializable"))
+                    return 1
+                }
+        
+                override fun update(task: KAtomicActionTask): Int {
+                    TODO("Not yet implemented")
+                }
+        
+                override fun batchUpdate(task: KronosAtomicBatchTask): IntArray {
+                    TODO("Not yet implemented")
+                }
+        
+                override fun transact(block: (DataSource) -> Any?): Any? {
+                    TODO("Not yet implemented")
+                }
+        
+            }
+
+            data class User(
+                val id: Int? = null
+            ): KPojo
+
+            data class Email(
+                val id: Int? = null,
+                val userId: Int? = null,
+            ): KPojo
+                
+            fun main() {
+                Kronos.apply {
+                    fieldNamingStrategy = lineHumpNamingStrategy
+                    tableNamingStrategy = lineHumpNamingStrategy
+                    dataSource = { TestWrapper }
+                }
+                
+                //inject
+                
+                test()
+            }
+        """
+
+    @OptIn(ExperimentalCompilerApi::class)
+    infix fun String.testCompile(@Language("kotlin") code: String) {
+        if (this.any { !it.isLetter() } || this.first().isLowerCase()) {
+            throw IllegalArgumentException("测试名称必须全部都是字母，且首字母必须大写")
+        }
+        val result =
+            compile(mainKt.replace("//inject", code), this@KQueryTaskTest.testBaseName + this)
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+
+        val ktClazz =
+            result.classLoader.loadClass("${this@KQueryTaskTest.testBaseName + this}Kt")
+        val main = ktClazz.declaredMethods.single { it.name == "main" && it.parameterCount == 0 }
+        main.invoke(null)
+    }
+}

--- a/kronos-core/src/main/kotlin/com/kotlinorm/beans/parser/NoneDataSourceWrapper.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/beans/parser/NoneDataSourceWrapper.kt
@@ -47,7 +47,7 @@ object NoneDataSourceWrapper : KronosDataSourceWrapper {
         throw NoDataSourceException(noDataSourceMessage)
     }
 
-    override fun forList(task: KAtomicQueryTask, kClass: KClass<*>): List<Any> {
+    override fun forList(task: KAtomicQueryTask, kClass: KClass<*>, isKPojo: Boolean, superTypes: List<String>): List<Any> {
         throw NoDataSourceException(noDataSourceMessage)
     }
 
@@ -55,7 +55,7 @@ object NoneDataSourceWrapper : KronosDataSourceWrapper {
         throw NoDataSourceException(noDataSourceMessage)
     }
 
-    override fun forObject(task: KAtomicQueryTask, kClass: KClass<*>): Any? {
+    override fun forObject(task: KAtomicQueryTask, kClass: KClass<*>, isKPojo: Boolean, superTypes: List<String>): Any? {
         throw NoDataSourceException(noDataSourceMessage)
     }
 

--- a/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosQueryTask.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosQueryTask.kt
@@ -54,10 +54,14 @@ class KronosQueryTask(val atomicTask: KronosAtomicQueryTask) { //原子任务
 
     @Suppress("UNCHECKED_CAST")
     // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
-    inline fun <reified T> queryList(wrapper: KronosDataSourceWrapper? = null, superTypes: List<String>): List<T> {
+    inline fun <reified T> queryList(
+        wrapper: KronosDataSourceWrapper? = null,
+        isKPojo: Boolean = true,
+        superTypes: List<String> = listOf()
+    ): List<T> {
         beforeQuery?.invoke(this)
         val result = atomicTask.logAndReturn(
-            wrapper.orDefault().forList(atomicTask, T::class, superTypes) as List<T>, QueryList
+            wrapper.orDefault().forList(atomicTask, T::class, isKPojo, superTypes) as List<T>, QueryList
         )
         afterQuery?.invoke(result, QueryList, wrapper.orDefault())
         return result
@@ -78,10 +82,16 @@ class KronosQueryTask(val atomicTask: KronosAtomicQueryTask) { //原子任务
     }
 
     // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
-    inline fun <reified T> queryOne(wrapper: KronosDataSourceWrapper? = null, superTypes: List<String>): T {
+    inline fun <reified T> queryOne(
+        wrapper: KronosDataSourceWrapper? = null,
+        isKPojo: Boolean = false,
+        superTypes: List<String> = listOf()
+    ): T {
         beforeQuery?.invoke(this)
         val result = atomicTask.logAndReturn(
-            wrapper.orDefault().forObject(atomicTask, T::class, superTypes) as T ?: throw NullPointerException("No such record"),
+            wrapper.orDefault().forObject(atomicTask, T::class, isKPojo, superTypes) as T ?: throw NullPointerException(
+                "No such record"
+            ),
             QueryOne
         )
         afterQuery?.invoke(result, QueryOne, wrapper.orDefault())
@@ -89,11 +99,15 @@ class KronosQueryTask(val atomicTask: KronosAtomicQueryTask) { //原子任务
     }
 
     // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
-    inline fun <reified T> queryOneOrNull(wrapper: KronosDataSourceWrapper? = null, superTypes: List<String>): T? {
+    inline fun <reified T> queryOneOrNull(
+        wrapper: KronosDataSourceWrapper? = null,
+        isKPojo: Boolean = false,
+        superTypes: List<String> = listOf()
+    ): T? {
         beforeQuery?.invoke(this)
         val result =
             atomicTask.logAndReturn(
-                wrapper.orDefault().forObject(atomicTask, T::class, superTypes) as T?,
+                wrapper.orDefault().forObject(atomicTask, T::class, isKPojo, superTypes) as T?,
                 QueryOneOrNull
             )
         afterQuery?.invoke(

--- a/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosQueryTask.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosQueryTask.kt
@@ -56,7 +56,7 @@ class KronosQueryTask(val atomicTask: KronosAtomicQueryTask) { //原子任务
     // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
     inline fun <reified T> queryList(
         wrapper: KronosDataSourceWrapper? = null,
-        isKPojo: Boolean = true,
+        isKPojo: Boolean = false,
         superTypes: List<String> = listOf()
     ): List<T> {
         beforeQuery?.invoke(this)

--- a/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosQueryTask.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosQueryTask.kt
@@ -53,7 +53,6 @@ class KronosQueryTask(val atomicTask: KronosAtomicQueryTask) { //原子任务
     }
 
     @Suppress("UNCHECKED_CAST")
-    // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
     inline fun <reified T> queryList(
         wrapper: KronosDataSourceWrapper? = null,
         isKPojo: Boolean = false,
@@ -81,7 +80,6 @@ class KronosQueryTask(val atomicTask: KronosAtomicQueryTask) { //原子任务
         return result
     }
 
-    // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
     inline fun <reified T> queryOne(
         wrapper: KronosDataSourceWrapper? = null,
         isKPojo: Boolean = false,
@@ -98,7 +96,6 @@ class KronosQueryTask(val atomicTask: KronosAtomicQueryTask) { //原子任务
         return result
     }
 
-    // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
     inline fun <reified T> queryOneOrNull(
         wrapper: KronosDataSourceWrapper? = null,
         isKPojo: Boolean = false,

--- a/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosQueryTask.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosQueryTask.kt
@@ -53,10 +53,11 @@ class KronosQueryTask(val atomicTask: KronosAtomicQueryTask) { //原子任务
     }
 
     @Suppress("UNCHECKED_CAST")
-    inline fun <reified T> queryList(wrapper: KronosDataSourceWrapper? = null): List<T> {
+    // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
+    inline fun <reified T> queryList(wrapper: KronosDataSourceWrapper? = null, superTypes: List<String>): List<T> {
         beforeQuery?.invoke(this)
         val result = atomicTask.logAndReturn(
-            wrapper.orDefault().forList(atomicTask, T::class) as List<T>, QueryList
+            wrapper.orDefault().forList(atomicTask, T::class, superTypes) as List<T>, QueryList
         )
         afterQuery?.invoke(result, QueryList, wrapper.orDefault())
         return result
@@ -76,21 +77,23 @@ class KronosQueryTask(val atomicTask: KronosAtomicQueryTask) { //原子任务
         return result
     }
 
-    inline fun <reified T> queryOne(wrapper: KronosDataSourceWrapper? = null): T {
+    // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
+    inline fun <reified T> queryOne(wrapper: KronosDataSourceWrapper? = null, superTypes: List<String>): T {
         beforeQuery?.invoke(this)
         val result = atomicTask.logAndReturn(
-            wrapper.orDefault().forObject(atomicTask, T::class) as T ?: throw NullPointerException("No such record"),
+            wrapper.orDefault().forObject(atomicTask, T::class, superTypes) as T ?: throw NullPointerException("No such record"),
             QueryOne
         )
         afterQuery?.invoke(result, QueryOne, wrapper.orDefault())
         return result
     }
 
-    inline fun <reified T> queryOneOrNull(wrapper: KronosDataSourceWrapper? = null): T? {
+    // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
+    inline fun <reified T> queryOneOrNull(wrapper: KronosDataSourceWrapper? = null, superTypes: List<String>): T? {
         beforeQuery?.invoke(this)
         val result =
             atomicTask.logAndReturn(
-                wrapper.orDefault().forObject(atomicTask, T::class) as T?,
+                wrapper.orDefault().forObject(atomicTask, T::class, superTypes) as T?,
                 QueryOneOrNull
             )
         afterQuery?.invoke(

--- a/kronos-core/src/main/kotlin/com/kotlinorm/database/SqlHandler.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/database/SqlHandler.kt
@@ -31,23 +31,34 @@ object SqlHandler {
     }
 
     @Suppress("UNCHECKED_CAST")
+    // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
     inline fun <reified T> KronosDataSourceWrapper.queryList(
         sql: String,
-        paramMap: Map<String, Any?> = emptyMap()
+        paramMap: Map<String, Any?> = emptyMap(),
+        isKPojo: Boolean = false,
+        superTypes: List<String> = emptyList()
     ): List<T> {
-        return this.forList(KronosAtomicQueryTask(sql, paramMap), T::class) as List<T>
+        return this.forList(KronosAtomicQueryTask(sql, paramMap), T::class, isKPojo, superTypes) as List<T>
     }
 
-    inline fun <reified T> KronosDataSourceWrapper.queryOne(sql: String, paramMap: Map<String, Any?> = emptyMap()): T {
-        return this.forObject(KronosAtomicQueryTask(sql, paramMap), T::class) as T?
+    // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
+    inline fun <reified T> KronosDataSourceWrapper.queryOne(
+        sql: String, paramMap: Map<String, Any?> = emptyMap(),
+        isKPojo: Boolean = false,
+        superTypes: List<String> = emptyList()
+    ): T {
+        return this.forObject(KronosAtomicQueryTask(sql, paramMap), T::class, isKPojo, superTypes) as T?
             ?: throw Exception("No result found")
     }
 
+    // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
     inline fun <reified T> KronosDataSourceWrapper.queryOneOrNull(
         sql: String,
-        paramMap: Map<String, Any?> = emptyMap()
+        paramMap: Map<String, Any?> = emptyMap(),
+        isKPojo: Boolean = false,
+        superTypes: List<String> = emptyList()
     ): T? {
-        return this.forObject(KronosAtomicQueryTask(sql, paramMap), T::class) as T?
+        return this.forObject(KronosAtomicQueryTask(sql, paramMap), T::class, isKPojo, superTypes) as T?
     }
 
     fun KronosDataSourceWrapper.execute(sql: String, paramMap: Map<String, Any?> = emptyMap()): Int {

--- a/kronos-core/src/main/kotlin/com/kotlinorm/database/SqlHandler.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/database/SqlHandler.kt
@@ -31,7 +31,6 @@ object SqlHandler {
     }
 
     @Suppress("UNCHECKED_CAST")
-    // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
     inline fun <reified T> KronosDataSourceWrapper.queryList(
         sql: String,
         paramMap: Map<String, Any?> = emptyMap(),
@@ -41,7 +40,6 @@ object SqlHandler {
         return this.forList(KronosAtomicQueryTask(sql, paramMap), T::class, isKPojo, superTypes) as List<T>
     }
 
-    // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
     inline fun <reified T> KronosDataSourceWrapper.queryOne(
         sql: String, paramMap: Map<String, Any?> = emptyMap(),
         isKPojo: Boolean = false,
@@ -51,7 +49,6 @@ object SqlHandler {
             ?: throw Exception("No result found")
     }
 
-    // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
     inline fun <reified T> KronosDataSourceWrapper.queryOneOrNull(
         sql: String,
         paramMap: Map<String, Any?> = emptyMap(),

--- a/kronos-core/src/main/kotlin/com/kotlinorm/database/sqlite/SqliteSupport.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/database/sqlite/SqliteSupport.kt
@@ -133,7 +133,9 @@ object SqliteSupport : DatabasesSupport {
                     KronosAtomicQueryTask(
                         "SELECT sql FROM sqlite_master WHERE tbl_name=:tableName AND sql LIKE '%AUTOINCREMENT%'",
                         mapOf("tableName" to tableName)
-                    ), String::class
+                    ), String::class,
+                    false,
+                    listOf()
                 ) as String?
                 if(sql != null && Regex("""("?\w+"?)\sINTEGER\sNOT\sNULL\sPRIMARY\sKEY\sAUTOINCREMENT""").find(sql)?.groupValues?.get(
                         1

--- a/kronos-core/src/main/kotlin/com/kotlinorm/interfaces/KronosDataSourceWrapper.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/interfaces/KronosDataSourceWrapper.kt
@@ -98,7 +98,8 @@ interface KronosDataSourceWrapper {
      */
     fun forList(
         task: KAtomicQueryTask,
-        kClass: KClass<*>
+        kClass: KClass<*>,
+        superTypes: List<String>
     ): List<Any>
 
     /**
@@ -125,7 +126,8 @@ interface KronosDataSourceWrapper {
      */
     fun forObject(
         task: KAtomicQueryTask,
-        kClass: KClass<*>
+        kClass: KClass<*>,
+        superTypes: List<String>
     ): Any?
 
     /**

--- a/kronos-core/src/main/kotlin/com/kotlinorm/interfaces/KronosDataSourceWrapper.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/interfaces/KronosDataSourceWrapper.kt
@@ -99,6 +99,7 @@ interface KronosDataSourceWrapper {
     fun forList(
         task: KAtomicQueryTask,
         kClass: KClass<*>,
+        isKPojo: Boolean,
         superTypes: List<String>
     ): List<Any>
 
@@ -127,6 +128,7 @@ interface KronosDataSourceWrapper {
     fun forObject(
         task: KAtomicQueryTask,
         kClass: KClass<*>,
+        isKPojo: Boolean,
         superTypes: List<String>
     ): Any?
 

--- a/kronos-core/src/main/kotlin/com/kotlinorm/orm/database/TableOperationUtil.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/orm/database/TableOperationUtil.kt
@@ -28,7 +28,9 @@ fun queryTableExistence(tableName: String, dataSource: KronosDataSourceWrapper):
             "dbName" to getDBNameFrom(dataSource)
         )
     ),
-    Int::class
+    Int::class,
+    false,
+    listOf()
 ) as Int) > 0
 
 fun queryTableComment(tableName: String, dataSource: KronosDataSourceWrapper): String {
@@ -40,7 +42,9 @@ fun queryTableComment(tableName: String, dataSource: KronosDataSourceWrapper): S
                 "dbName" to getDBNameFrom(dataSource)
             )
         ),
-        String::class
+        String::class,
+        false,
+        listOf()
     ) as String? ?: ""
 }
 

--- a/kronos-core/src/main/kotlin/com/kotlinorm/orm/join/SelectFrom.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/orm/join/SelectFrom.kt
@@ -21,9 +21,9 @@ import com.kotlinorm.beans.dsl.Criteria
 import com.kotlinorm.beans.dsl.Field
 import com.kotlinorm.beans.dsl.KJoinable
 import com.kotlinorm.beans.dsl.KSelectable
-import com.kotlinorm.beans.dsl.KTableForSelect.Companion.afterSelect
 import com.kotlinorm.beans.dsl.KTableForCondition.Companion.afterFilter
 import com.kotlinorm.beans.dsl.KTableForReference.Companion.afterReference
+import com.kotlinorm.beans.dsl.KTableForSelect.Companion.afterSelect
 import com.kotlinorm.beans.dsl.KTableForSort.Companion.afterSort
 import com.kotlinorm.beans.task.KronosAtomicQueryTask
 import com.kotlinorm.beans.task.KronosQueryTask
@@ -51,7 +51,7 @@ import com.kotlinorm.utils.Extensions.toCriteria
 import com.kotlinorm.utils.logAndReturn
 import com.kotlinorm.utils.setCommonStrategy
 import com.kotlinorm.utils.toLinkedSet
-import java.util.Stack
+import java.util.*
 
 /**
  * Select From
@@ -460,8 +460,12 @@ open class SelectFrom<T1 : KPojo>(open val t1: T1) : KSelectable<T1>(t1) {
     }
 
     // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
-    inline fun <reified T> queryList(wrapper: KronosDataSourceWrapper? = null, superTypes: List<String> = emptyList()): List<T> {
-        return this.build().queryList(wrapper, superTypes)
+    inline fun <reified T> queryList(
+        wrapper: KronosDataSourceWrapper? = null,
+        isKPojo: Boolean = true,
+        superTypes: List<String> = listOf()
+    ): List<T> {
+        return this.build().queryList(wrapper, isKPojo, superTypes)
     }
 
     @JvmName("queryForList")
@@ -470,7 +474,7 @@ open class SelectFrom<T1 : KPojo>(open val t1: T1) : KSelectable<T1>(t1) {
         with(this.build()) {
             beforeQuery?.invoke(this)
             val result = atomicTask.logAndReturn(
-                wrapper.orDefault().forList(atomicTask, pojo::class, listOf("com.kotlinorm.interfaces.KPojo")) as List<T1>,
+                wrapper.orDefault().forList(atomicTask, pojo::class, true, listOf()) as List<T1>,
                 QueryType.QueryList
             )
             afterQuery?.invoke(result, QueryType.QueryList, wrapper.orDefault())
@@ -487,8 +491,12 @@ open class SelectFrom<T1 : KPojo>(open val t1: T1) : KSelectable<T1>(t1) {
     }
 
     // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
-    inline fun <reified T> queryOne(wrapper: KronosDataSourceWrapper? = null, superTypes: List<String> = emptyList()): T {
-        return this.build().queryOne(wrapper, superTypes)
+    inline fun <reified T> queryOne(
+        wrapper: KronosDataSourceWrapper? = null,
+        isKPojo: Boolean = true,
+        superTypes: List<String> = listOf()
+    ): T {
+        return this.build().queryOne(wrapper, isKPojo, superTypes)
     }
 
     @JvmName("queryForObject")
@@ -497,7 +505,7 @@ open class SelectFrom<T1 : KPojo>(open val t1: T1) : KSelectable<T1>(t1) {
         with(this.build()) {
             beforeQuery?.invoke(this)
             val result = atomicTask.logAndReturn(
-                (wrapper.orDefault().forObject(atomicTask, pojo::class, listOf("com.kotlinorm.interfaces.KPojo"))
+                (wrapper.orDefault().forObject(atomicTask, pojo::class, true, listOf())
                     ?: throw NullPointerException("No such record")) as T1,
                 QueryType.QueryOne
             )
@@ -507,8 +515,12 @@ open class SelectFrom<T1 : KPojo>(open val t1: T1) : KSelectable<T1>(t1) {
     }
 
     // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
-    inline fun <reified T> queryOneOrNull(wrapper: KronosDataSourceWrapper? = null, superTypes: List<String> = emptyList()): T? {
-        return this.build().queryOneOrNull(wrapper, superTypes)
+    inline fun <reified T> queryOneOrNull(
+        wrapper: KronosDataSourceWrapper? = null,
+        isKPojo: Boolean = true,
+        superTypes: List<String> = listOf()
+    ): T? {
+        return this.build().queryOneOrNull(wrapper, isKPojo, superTypes)
     }
 
     @JvmName("queryForObjectOrNull")
@@ -517,7 +529,7 @@ open class SelectFrom<T1 : KPojo>(open val t1: T1) : KSelectable<T1>(t1) {
         with(this.build()) {
             beforeQuery?.invoke(this)
             val result = atomicTask.logAndReturn(
-                wrapper.orDefault().forObject(atomicTask, pojo::class, listOf("com.kotlinorm.interfaces.KPojo")) as T1?,
+                wrapper.orDefault().forObject(atomicTask, pojo::class, true, listOf()) as T1?,
                 QueryType.QueryOneOrNull
             )
             afterQuery?.invoke(result, QueryType.QueryOneOrNull, wrapper.orDefault())

--- a/kronos-core/src/main/kotlin/com/kotlinorm/orm/join/SelectFrom.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/orm/join/SelectFrom.kt
@@ -459,7 +459,6 @@ open class SelectFrom<T1 : KPojo>(open val t1: T1) : KSelectable<T1>(t1) {
         return this.build().query(wrapper)
     }
 
-    // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
     inline fun <reified T> queryList(
         wrapper: KronosDataSourceWrapper? = null,
         isKPojo: Boolean = false,
@@ -490,7 +489,6 @@ open class SelectFrom<T1 : KPojo>(open val t1: T1) : KSelectable<T1>(t1) {
         return this.build().queryMapOrNull(wrapper)
     }
 
-    // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
     inline fun <reified T> queryOne(
         wrapper: KronosDataSourceWrapper? = null,
         isKPojo: Boolean = false,
@@ -514,7 +512,6 @@ open class SelectFrom<T1 : KPojo>(open val t1: T1) : KSelectable<T1>(t1) {
         }
     }
 
-    // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
     inline fun <reified T> queryOneOrNull(
         wrapper: KronosDataSourceWrapper? = null,
         isKPojo: Boolean = false,

--- a/kronos-core/src/main/kotlin/com/kotlinorm/orm/join/SelectFrom.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/orm/join/SelectFrom.kt
@@ -459,8 +459,9 @@ open class SelectFrom<T1 : KPojo>(open val t1: T1) : KSelectable<T1>(t1) {
         return this.build().query(wrapper)
     }
 
-    inline fun <reified T> queryList(wrapper: KronosDataSourceWrapper? = null): List<T> {
-        return this.build().queryList(wrapper)
+    // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
+    inline fun <reified T> queryList(wrapper: KronosDataSourceWrapper? = null, superTypes: List<String> = emptyList()): List<T> {
+        return this.build().queryList(wrapper, superTypes)
     }
 
     @JvmName("queryForList")
@@ -469,7 +470,7 @@ open class SelectFrom<T1 : KPojo>(open val t1: T1) : KSelectable<T1>(t1) {
         with(this.build()) {
             beforeQuery?.invoke(this)
             val result = atomicTask.logAndReturn(
-                wrapper.orDefault().forList(atomicTask, pojo::class) as List<T1>,
+                wrapper.orDefault().forList(atomicTask, pojo::class, listOf("com.kotlinorm.interfaces.KPojo")) as List<T1>,
                 QueryType.QueryList
             )
             afterQuery?.invoke(result, QueryType.QueryList, wrapper.orDefault())
@@ -485,8 +486,9 @@ open class SelectFrom<T1 : KPojo>(open val t1: T1) : KSelectable<T1>(t1) {
         return this.build().queryMapOrNull(wrapper)
     }
 
-    inline fun <reified T> queryOne(wrapper: KronosDataSourceWrapper? = null): T {
-        return this.build().queryOne(wrapper)
+    // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
+    inline fun <reified T> queryOne(wrapper: KronosDataSourceWrapper? = null, superTypes: List<String> = emptyList()): T {
+        return this.build().queryOne(wrapper, superTypes)
     }
 
     @JvmName("queryForObject")
@@ -495,7 +497,7 @@ open class SelectFrom<T1 : KPojo>(open val t1: T1) : KSelectable<T1>(t1) {
         with(this.build()) {
             beforeQuery?.invoke(this)
             val result = atomicTask.logAndReturn(
-                (wrapper.orDefault().forObject(atomicTask, pojo::class)
+                (wrapper.orDefault().forObject(atomicTask, pojo::class, listOf("com.kotlinorm.interfaces.KPojo"))
                     ?: throw NullPointerException("No such record")) as T1,
                 QueryType.QueryOne
             )
@@ -504,8 +506,9 @@ open class SelectFrom<T1 : KPojo>(open val t1: T1) : KSelectable<T1>(t1) {
         }
     }
 
-    inline fun <reified T> queryOneOrNull(wrapper: KronosDataSourceWrapper? = null): T? {
-        return this.build().queryOneOrNull(wrapper)
+    // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
+    inline fun <reified T> queryOneOrNull(wrapper: KronosDataSourceWrapper? = null, superTypes: List<String> = emptyList()): T? {
+        return this.build().queryOneOrNull(wrapper, superTypes)
     }
 
     @JvmName("queryForObjectOrNull")
@@ -514,7 +517,7 @@ open class SelectFrom<T1 : KPojo>(open val t1: T1) : KSelectable<T1>(t1) {
         with(this.build()) {
             beforeQuery?.invoke(this)
             val result = atomicTask.logAndReturn(
-                wrapper.orDefault().forObject(atomicTask, pojo::class) as T1?,
+                wrapper.orDefault().forObject(atomicTask, pojo::class, listOf("com.kotlinorm.interfaces.KPojo")) as T1?,
                 QueryType.QueryOneOrNull
             )
             afterQuery?.invoke(result, QueryType.QueryOneOrNull, wrapper.orDefault())

--- a/kronos-core/src/main/kotlin/com/kotlinorm/orm/join/SelectFrom.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/orm/join/SelectFrom.kt
@@ -462,7 +462,7 @@ open class SelectFrom<T1 : KPojo>(open val t1: T1) : KSelectable<T1>(t1) {
     // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
     inline fun <reified T> queryList(
         wrapper: KronosDataSourceWrapper? = null,
-        isKPojo: Boolean = true,
+        isKPojo: Boolean = false,
         superTypes: List<String> = listOf()
     ): List<T> {
         return this.build().queryList(wrapper, isKPojo, superTypes)
@@ -493,7 +493,7 @@ open class SelectFrom<T1 : KPojo>(open val t1: T1) : KSelectable<T1>(t1) {
     // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
     inline fun <reified T> queryOne(
         wrapper: KronosDataSourceWrapper? = null,
-        isKPojo: Boolean = true,
+        isKPojo: Boolean = false,
         superTypes: List<String> = listOf()
     ): T {
         return this.build().queryOne(wrapper, isKPojo, superTypes)
@@ -517,7 +517,7 @@ open class SelectFrom<T1 : KPojo>(open val t1: T1) : KSelectable<T1>(t1) {
     // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
     inline fun <reified T> queryOneOrNull(
         wrapper: KronosDataSourceWrapper? = null,
-        isKPojo: Boolean = true,
+        isKPojo: Boolean = false,
         superTypes: List<String> = listOf()
     ): T? {
         return this.build().queryOneOrNull(wrapper, isKPojo, superTypes)

--- a/kronos-core/src/main/kotlin/com/kotlinorm/orm/pagination/PagedClause.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/orm/pagination/PagedClause.kt
@@ -52,7 +52,7 @@ class PagedClause<K : KPojo, T : KSelectable<K>>(
             beforeQuery?.invoke(this)
             val records =
                 atomicTask.logAndReturn(
-                    wrapper.orDefault().forList(atomicTask, selectClause.pojo::class), QueryList
+                    wrapper.orDefault().forList(atomicTask, selectClause.pojo::class, true, listOf()), QueryList
                 )
 
             afterQuery?.invoke(records, QueryList, wrapper.orDefault())

--- a/kronos-core/src/main/kotlin/com/kotlinorm/orm/select/SelectClause.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/orm/select/SelectClause.kt
@@ -351,8 +351,9 @@ class SelectClause<T : KPojo>(
         return this.build().query(wrapper)
     }
 
-    inline fun <reified T> queryList(wrapper: KronosDataSourceWrapper? = null): List<T> {
-        return this.build().queryList(wrapper)
+    // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
+    inline fun <reified T> queryList(wrapper: KronosDataSourceWrapper? = null, superTypes: List<String> = emptyList()): List<T> {
+        return this.build().queryList(wrapper, superTypes)
     }
 
     @JvmName("queryForList")
@@ -361,7 +362,7 @@ class SelectClause<T : KPojo>(
         with(this.build()) {
             beforeQuery?.invoke(this)
             val result = atomicTask.logAndReturn(
-                wrapper.orDefault().forList(atomicTask, pojo::class) as List<T>, QueryList
+                wrapper.orDefault().forList(atomicTask, pojo::class, listOf("com.kotlinorm.interfaces.KPojo")) as List<T>, QueryList
             )
             afterQuery?.invoke(result, QueryList, wrapper.orDefault())
             return result
@@ -377,8 +378,9 @@ class SelectClause<T : KPojo>(
         return this.build().queryMapOrNull(wrapper)
     }
 
-    inline fun <reified T> queryOne(wrapper: KronosDataSourceWrapper? = null): T {
-        return this.build().queryOne(wrapper)
+    // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
+    inline fun <reified T> queryOne(wrapper: KronosDataSourceWrapper? = null, superTypes: List<String> = emptyList()): T {
+        return this.build().queryOne(wrapper, superTypes)
     }
 
     @JvmName("queryForObject")
@@ -387,7 +389,7 @@ class SelectClause<T : KPojo>(
         with(this.build()) {
             beforeQuery?.invoke(this)
             val result = atomicTask.logAndReturn(
-                (wrapper.orDefault().forObject(atomicTask, pojo::class)
+                (wrapper.orDefault().forObject(atomicTask, pojo::class, listOf("com.kotlinorm.interfaces.KPojo"))
                     ?: throw NullPointerException("No such record")) as T, QueryOne
             )
             afterQuery?.invoke(result, QueryOne, wrapper.orDefault())
@@ -395,8 +397,9 @@ class SelectClause<T : KPojo>(
         }
     }
 
-    inline fun <reified T> queryOneOrNull(wrapper: KronosDataSourceWrapper? = null): T? {
-        return this.build().queryOneOrNull(wrapper)
+    // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
+    inline fun <reified T> queryOneOrNull(wrapper: KronosDataSourceWrapper? = null, superTypes: List<String> = emptyList()): T? {
+        return this.build().queryOneOrNull(wrapper, superTypes)
     }
 
     @JvmName("queryForObjectOrNull")
@@ -405,7 +408,7 @@ class SelectClause<T : KPojo>(
         with(build()) {
             beforeQuery?.invoke(this)
             val result = atomicTask.logAndReturn(
-                wrapper.orDefault().forObject(atomicTask, pojo::class) as T?, QueryOneOrNull
+                wrapper.orDefault().forObject(atomicTask, pojo::class, listOf("com.kotlinorm.interfaces.KPojo")) as T?, QueryOneOrNull
             )
             afterQuery?.invoke(result, QueryOneOrNull, wrapper.orDefault())
             return result

--- a/kronos-core/src/main/kotlin/com/kotlinorm/orm/select/SelectClause.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/orm/select/SelectClause.kt
@@ -351,7 +351,6 @@ class SelectClause<T : KPojo>(
         return this.build().query(wrapper)
     }
 
-    // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
     inline fun <reified T> queryList(wrapper: KronosDataSourceWrapper? = null, isKPojo: Boolean = false, superTypes: List<String> = listOf()): List<T> {
         return this.build().queryList(wrapper, isKPojo, superTypes)
     }
@@ -378,7 +377,6 @@ class SelectClause<T : KPojo>(
         return this.build().queryMapOrNull(wrapper)
     }
 
-    // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
     inline fun <reified T> queryOne(wrapper: KronosDataSourceWrapper? = null, isKPojo: Boolean = false, superTypes: List<String> = listOf()): T {
         return this.build().queryOne(wrapper, isKPojo, superTypes)
     }
@@ -397,7 +395,6 @@ class SelectClause<T : KPojo>(
         }
     }
 
-    // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
     inline fun <reified T> queryOneOrNull(wrapper: KronosDataSourceWrapper? = null, isKPojo: Boolean = false, superTypes: List<String> = listOf()): T? {
         return this.build().queryOneOrNull(wrapper, isKPojo, superTypes)
     }

--- a/kronos-core/src/main/kotlin/com/kotlinorm/orm/select/SelectClause.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/orm/select/SelectClause.kt
@@ -18,7 +18,6 @@ package com.kotlinorm.orm.select
 
 import com.kotlinorm.beans.dsl.Criteria
 import com.kotlinorm.beans.dsl.Field
-import com.kotlinorm.interfaces.KPojo
 import com.kotlinorm.beans.dsl.KSelectable
 import com.kotlinorm.beans.dsl.KTableForCondition.Companion.afterFilter
 import com.kotlinorm.beans.dsl.KTableForReference.Companion.afterReference
@@ -37,6 +36,7 @@ import com.kotlinorm.enums.QueryType.QueryOne
 import com.kotlinorm.enums.QueryType.QueryOneOrNull
 import com.kotlinorm.enums.SortType
 import com.kotlinorm.exceptions.NeedFieldsException
+import com.kotlinorm.interfaces.KPojo
 import com.kotlinorm.interfaces.KronosDataSourceWrapper
 import com.kotlinorm.orm.cascade.CascadeSelectClause
 import com.kotlinorm.orm.pagination.PagedClause
@@ -352,8 +352,8 @@ class SelectClause<T : KPojo>(
     }
 
     // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
-    inline fun <reified T> queryList(wrapper: KronosDataSourceWrapper? = null, superTypes: List<String> = emptyList()): List<T> {
-        return this.build().queryList(wrapper, superTypes)
+    inline fun <reified T> queryList(wrapper: KronosDataSourceWrapper? = null, isKPojo: Boolean = false, superTypes: List<String> = listOf()): List<T> {
+        return this.build().queryList(wrapper, isKPojo, superTypes)
     }
 
     @JvmName("queryForList")
@@ -362,7 +362,7 @@ class SelectClause<T : KPojo>(
         with(this.build()) {
             beforeQuery?.invoke(this)
             val result = atomicTask.logAndReturn(
-                wrapper.orDefault().forList(atomicTask, pojo::class, listOf("com.kotlinorm.interfaces.KPojo")) as List<T>, QueryList
+                wrapper.orDefault().forList(atomicTask, pojo::class, true, listOf()) as List<T>, QueryList
             )
             afterQuery?.invoke(result, QueryList, wrapper.orDefault())
             return result
@@ -379,8 +379,8 @@ class SelectClause<T : KPojo>(
     }
 
     // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
-    inline fun <reified T> queryOne(wrapper: KronosDataSourceWrapper? = null, superTypes: List<String> = emptyList()): T {
-        return this.build().queryOne(wrapper, superTypes)
+    inline fun <reified T> queryOne(wrapper: KronosDataSourceWrapper? = null, isKPojo: Boolean = false, superTypes: List<String> = listOf()): T {
+        return this.build().queryOne(wrapper, isKPojo, superTypes)
     }
 
     @JvmName("queryForObject")
@@ -389,7 +389,7 @@ class SelectClause<T : KPojo>(
         with(this.build()) {
             beforeQuery?.invoke(this)
             val result = atomicTask.logAndReturn(
-                (wrapper.orDefault().forObject(atomicTask, pojo::class, listOf("com.kotlinorm.interfaces.KPojo"))
+                (wrapper.orDefault().forObject(atomicTask, pojo::class, true, listOf())
                     ?: throw NullPointerException("No such record")) as T, QueryOne
             )
             afterQuery?.invoke(result, QueryOne, wrapper.orDefault())
@@ -398,8 +398,8 @@ class SelectClause<T : KPojo>(
     }
 
     // TODO: COMPILER SHOULD SUPPLY THE SUPER TYPES
-    inline fun <reified T> queryOneOrNull(wrapper: KronosDataSourceWrapper? = null, superTypes: List<String> = emptyList()): T? {
-        return this.build().queryOneOrNull(wrapper, superTypes)
+    inline fun <reified T> queryOneOrNull(wrapper: KronosDataSourceWrapper? = null, isKPojo: Boolean = false, superTypes: List<String> = listOf()): T? {
+        return this.build().queryOneOrNull(wrapper, isKPojo, superTypes)
     }
 
     @JvmName("queryForObjectOrNull")
@@ -408,7 +408,7 @@ class SelectClause<T : KPojo>(
         with(build()) {
             beforeQuery?.invoke(this)
             val result = atomicTask.logAndReturn(
-                wrapper.orDefault().forObject(atomicTask, pojo::class, listOf("com.kotlinorm.interfaces.KPojo")) as T?, QueryOneOrNull
+                wrapper.orDefault().forObject(atomicTask, pojo::class, true, listOf()) as T?, QueryOneOrNull
             )
             afterQuery?.invoke(result, QueryOneOrNull, wrapper.orDefault())
             return result

--- a/kronos-core/src/main/kotlin/com/kotlinorm/utils/TaskUtil.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/utils/TaskUtil.kt
@@ -54,11 +54,9 @@ import com.kotlinorm.enums.QueryType.QueryOne
 import com.kotlinorm.enums.QueryType.QueryOneOrNull
 import com.kotlinorm.interfaces.KAtomicTask
 import com.kotlinorm.interfaces.KAtomicActionTask
-import com.kotlinorm.interfaces.KAtomicQueryTask
 import com.kotlinorm.interfaces.KBatchTask
 import com.kotlinorm.interfaces.KronosDataSourceWrapper
 import com.kotlinorm.utils.DataSourceUtil.orDefault
-import com.sun.org.apache.xpath.internal.operations.Bool
 
 // Generates the SQL statement needed to obtain the last inserted ID based on the provided database type.
 fun lastInsertIdObtainSql(dbType: DBType): String {

--- a/kronos-core/src/main/kotlin/com/kotlinorm/utils/TaskUtil.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/utils/TaskUtil.kt
@@ -58,6 +58,7 @@ import com.kotlinorm.interfaces.KAtomicQueryTask
 import com.kotlinorm.interfaces.KBatchTask
 import com.kotlinorm.interfaces.KronosDataSourceWrapper
 import com.kotlinorm.utils.DataSourceUtil.orDefault
+import com.sun.org.apache.xpath.internal.operations.Bool
 
 // Generates the SQL statement needed to obtain the last inserted ID based on the provided database type.
 fun lastInsertIdObtainSql(dbType: DBType): String {
@@ -91,30 +92,11 @@ fun KAtomicActionTask.execute(wrapper: KronosDataSourceWrapper?): KronosOperatio
     var lastInsertId: Long? = null
     if (operationType == INSERT && useIdentity) {
         lastInsertId = wrapper.orDefault().forObject(
-            KronosAtomicQueryTask(lastInsertIdObtainSql(wrapper.orDefault().dbType)), kClass = Long::class
+            KronosAtomicQueryTask(lastInsertIdObtainSql(wrapper.orDefault().dbType)), kClass = Long::class, false, listOf()
         ) as Long
     }
     return logAndReturn(KronosOperationResult(affectRows, lastInsertId))
 }
-
-fun KAtomicQueryTask.query(wrapper: KronosDataSourceWrapper? = null) =
-    logAndReturn(wrapper.orDefault().forList(this), Query)
-
-@Suppress("UNCHECKED_CAST")
-inline fun <reified T> KAtomicQueryTask.queryList(wrapper: KronosDataSourceWrapper? = null) =
-    logAndReturn(wrapper.orDefault().forList(this, T::class) as List<T>, QueryList)
-
-fun KAtomicQueryTask.queryMap(wrapper: KronosDataSourceWrapper? = null): Map<String, Any> =
-    logAndReturn(wrapper.orDefault().forMap(this)!!, QueryMap)
-
-fun KAtomicQueryTask.queryMapOrNull(wrapper: KronosDataSourceWrapper? = null): Map<String, Any>? =
-    logAndReturn(wrapper.orDefault().forMap(this), QueryMapOrNull)
-
-inline fun <reified T> KAtomicQueryTask.queryOne(wrapper: KronosDataSourceWrapper? = null) =
-    logAndReturn(wrapper.orDefault().forObject(this, T::class) as T? ?: throw NullPointerException("No such record"))
-
-inline fun <reified T> KAtomicQueryTask.queryOneOrNull(wrapper: KronosDataSourceWrapper? = null) =
-    logAndReturn(wrapper.orDefault().forObject(this, T::class) as T?, QueryOneOrNull)
 
 var kronosDoLog: (task: KAtomicTask, result: Any?, queryType: QueryType?) -> Unit = { task, result, queryType ->
     fun resultArr(): Array<KLogMessage> {

--- a/kronos-jdbc-wrapper/src/main/kotlin/com/kotlinorm/KronosBasicWrapper.kt
+++ b/kronos-jdbc-wrapper/src/main/kotlin/com/kotlinorm/KronosBasicWrapper.kt
@@ -109,8 +109,8 @@ class KronosBasicWrapper(private val dataSource: DataSource) : KronosDataSourceW
      * @return a list of objects of the specified class
      * @throws [SQLException] if an error occurs while executing the query
      */
-    override fun forList(task: KAtomicQueryTask, kClass: KClass<*>, superTypes: List<String>): List<Any> {
-        return if ("com.kotlinorm.interfaces.KPojo" in superTypes) {
+    override fun forList(task: KAtomicQueryTask, kClass: KClass<*>, isKPojo: Boolean, superTypes: List<String>): List<Any> {
+        return if (isKPojo) {
             @Suppress("UNCHECKED_CAST") forList(task).map { it.safeMapperTo(kClass as KClass<KPojo>) }
         } else {
             val (sql, paramList) = task.parsed()
@@ -203,8 +203,8 @@ class KronosBasicWrapper(private val dataSource: DataSource) : KronosDataSourceW
      * @throws [UnsupportedTypeException] If the provided class is not supported.
      * @throws [SQLException] If an error occurs while executing the query.
      */
-    override fun forObject(task: KAtomicQueryTask, kClass: KClass<*>, superTypes: List<String>): Any? {
-        return if ("com.kotlinorm.interfaces.KPojo" in superTypes) {
+    override fun forObject(task: KAtomicQueryTask, kClass: KClass<*>, isKPojo: Boolean, superTypes: List<String>): Any? {
+        return if (isKPojo) {
             @Suppress("UNCHECKED_CAST") forMap(task)?.safeMapperTo(kClass as KClass<KPojo>)
         } else {
             val (sql, paramList) = task.parsed()

--- a/kronos-testing/src/test/kotlin/com/kotlinorm/KronosJdbcWrapperTest.kt
+++ b/kronos-testing/src/test/kotlin/com/kotlinorm/KronosJdbcWrapperTest.kt
@@ -108,7 +108,9 @@ class BasicWrapperTest {
         testUpdate()
         val result = wrapper.forList(
             KronosAtomicQueryTask("select username, score, gender, create_time createTime, update_time updateTime from tb_user"),
-            MysqlUser::class
+            MysqlUser::class,
+            true,
+            listOf()
         )
         assertEquals(
             listOf(
@@ -125,7 +127,7 @@ class BasicWrapperTest {
     @Test
     fun testQueryListTypePrimitive() {
         testUpdate()
-        val result = wrapper.forList(KronosAtomicQueryTask("select score from tb_user"), Int::class)
+        val result = wrapper.forList(KronosAtomicQueryTask("select score from tb_user"), Int::class, false, listOf("Kotlin.Int"))
         assertEquals(
             listOf(1, 2, 3, 4, 5),
             result
@@ -136,14 +138,14 @@ class BasicWrapperTest {
     fun testQueryObject() {
         testUpdate()
         val result =
-            wrapper.forObject(KronosAtomicQueryTask("select * from tb_user where id = 1"), MysqlUser::class)
+            wrapper.forObject(KronosAtomicQueryTask("select * from tb_user where id = 1"), MysqlUser::class, true, listOf())
         assertEquals(MysqlUser(1, "test", 1, 1, deleted = false), result)
     }
 
     @Test
     fun testQueryObjectPrimitive() {
         testUpdate()
-        val result = wrapper.forObject(KronosAtomicQueryTask("select score from tb_user where id = 1"), Int::class)
+        val result = wrapper.forObject(KronosAtomicQueryTask("select score from tb_user where id = 1"), Int::class, false, listOf("Kotlin.Int"))
         assertEquals(1, result)
     }
 

--- a/kronos-testing/src/test/kotlin/com/kotlinorm/orm/relationQuery/RelationQuery.kt
+++ b/kronos-testing/src/test/kotlin/com/kotlinorm/orm/relationQuery/RelationQuery.kt
@@ -15,7 +15,6 @@ import com.kotlinorm.orm.relationQuery.oneToMany.Student
 import com.kotlinorm.orm.select.select
 import com.kotlinorm.orm.update.update
 import com.kotlinorm.orm.utils.GsonResolver
-import com.kotlinorm.utils.registerKPojo
 import org.apache.commons.dbcp2.BasicDataSource
 import kotlin.test.Test
 
@@ -33,14 +32,6 @@ class RelationQuery {
             tableNamingStrategy = lineHumpNamingStrategy
             dataSource = { KronosBasicWrapper(ds) }
             serializeResolver = GsonResolver
-            registerKPojo(
-                School::class,
-                GroupClass::class,
-                Student::class,
-                Role::class,
-                RolePermissionRelation::class,
-                Permission::class
-            )
         }
     }
 

--- a/kronos-testing/src/test/kotlin/com/kotlinorm/orm/utils/TestWrapper.kt
+++ b/kronos-testing/src/test/kotlin/com/kotlinorm/orm/utils/TestWrapper.kt
@@ -46,7 +46,7 @@ object TestWrapper : KronosDataSourceWrapper {
         )
     }
 
-    override fun forList(task: KAtomicQueryTask, kClass: KClass<*>): List<Any> {
+    override fun forList(task: KAtomicQueryTask, kClass: KClass<*>, isKPojo: Boolean, superTypes: List<String>): List<Any> {
         return listOf()
     }
 
@@ -54,7 +54,7 @@ object TestWrapper : KronosDataSourceWrapper {
         return null
     }
 
-    override fun forObject(task: KAtomicQueryTask, kClass: KClass<*>): Any? {
+    override fun forObject(task: KAtomicQueryTask, kClass: KClass<*>, isKPojo: Boolean, superTypes: List<String>): Any? {
         return null
     }
 

--- a/kronos-testing/src/test/kotlin/com/kotlinorm/utils/CommonUtilTest.kt
+++ b/kronos-testing/src/test/kotlin/com/kotlinorm/utils/CommonUtilTest.kt
@@ -13,6 +13,7 @@ import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.*
+import kotlin.streams.toList
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue


### PR DESCRIPTION
Providing default `supertypes` parameter for `queryList<refied T>()`, `queryOne<refied T>()`, and `queryOneOrNull<refied T>()` at compile time to remove dependency on reflection libraries can improve performance.

Consider whether to add an additional `isKPojo` parameter of type `Boolean` to drastically save conditional judgment at query time.