### PR TITLE
[Hook]  Add QueryEvent and ActionEvent to support task event registration

### DIFF
--- a/kronos-core/src/main/kotlin/com/kotlinorm/Kronos.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/Kronos.kt
@@ -26,6 +26,7 @@ import com.kotlinorm.beans.logging.BundledSimpleLoggerAdapter
 import com.kotlinorm.beans.logging.KLogMessage.Companion.kMsgOf
 import com.kotlinorm.beans.parser.NoneDataSourceWrapper
 import com.kotlinorm.beans.serialize.NoneSerializeProcessor
+import com.kotlinorm.beans.task.registerTaskEventPlugin
 import com.kotlinorm.enums.ColorPrintCode.Companion.Green
 import com.kotlinorm.enums.KLoggerType
 import com.kotlinorm.enums.PrimaryKeyType
@@ -33,6 +34,7 @@ import com.kotlinorm.interfaces.KronosDataSourceWrapper
 import com.kotlinorm.interfaces.KronosNamingStrategy
 import com.kotlinorm.interfaces.KronosSerializeProcessor
 import com.kotlinorm.interfaces.NoValueStrategy
+import com.kotlinorm.plugins.LastInsertIdPlugin
 import com.kotlinorm.types.KLoggerFactory
 import com.kotlinorm.utils.DataSourceUtil.orDefault
 import java.time.ZoneId
@@ -99,6 +101,7 @@ object Kronos {
 
     @KronosInit
     fun init(action: Kronos.() -> Unit) {
+        registerTaskEventPlugin(LastInsertIdPlugin)
         this.action()
         defaultLogger(this).info(
             kMsgOf("Kronos ORM Framework started.", Green).endl().toArray()

--- a/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosActionTask.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosActionTask.kt
@@ -95,35 +95,24 @@ class KronosActionTask {
     }
 
     companion object {
-        /**
-         * Converts a list of KronosAtomicActionTask to a single KronosActionTask.
-         *
-         * This function creates a new KronosActionTask and adds all the atomic tasks from the list to it.
-         * Each atomic task in the list is split out using the trySplitOut function, and the resulting tasks are flattened into a single list.
-         * The flattened list of tasks is then added to the atomic tasks of the new KronosActionTask.
-         *
-         * @receiver List<KronosAtomicActionTask> the list of KronosAtomicActionTask to convert.
-         * @return KronosActionTask returns a new KronosActionTask with all the atomic tasks from the list.
-         */
         fun List<KronosAtomicActionTask>.toKronosActionTask(): KronosActionTask {
-            return KronosActionTask().apply {
-                atomicTasks.addAll(map { it.trySplitOut() }.flatten())
+            return KronosActionTask().also {
+                it.atomicTasks.addAll(this)
             }
         }
 
         /**
-         * Converts a list of KronosAtomicActionTask to a single KronosActionTask.
+         * Converts a KronosAtomicActionTask to a KronosActionTask.
          *
-         * This function creates a new KronosActionTask and adds all the atomic tasks from the list to it.
-         * Each atomic task in the list is split out using the trySplitOut function, and the resulting tasks are flattened into a single list.
-         * The flattened list of tasks is then added to the atomic tasks of the new KronosActionTask.
+         * This function creates a new KronosActionTask and adds the current KronosAtomicActionTask to it.
+         * It also copies the stash from the current task to the new task.
          *
-         * @receiver List<KronosAtomicActionTask> the list of KronosAtomicActionTask to convert.
-         * @return KronosActionTask returns a new KronosActionTask with all the atomic tasks from the list.
+         * @receiver KronosAtomicActionTask the current KronosAtomicActionTask to convert.
+         * @return KronosActionTask returns a new KronosActionTask with the current task added to it.
          */
         fun KronosAtomicActionTask.toKronosActionTask(): KronosActionTask {
             return KronosActionTask().also {
-                it.atomicTasks.addAll(trySplitOut())
+                it.atomicTasks.add(this)
                 it.atomicTasks.forEach { task -> task.stash.putAll(stash) }
             }
         }

--- a/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosActionTask.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosActionTask.kt
@@ -88,7 +88,9 @@ class KronosActionTask {
         val affectRows = results.sumOf { it.affectedRows } //受影响的行数
         return KronosOperationResult(affectRows).apply {
             afterExecute?.invoke(this, dataSource) //在执行之后执行的操作
-            stash.putAll(results.last().stash)
+            if(results.isNotEmpty()) {
+                stash.putAll(results.last().stash) //将最后一个结果的stash放入当前结果
+            }
         }
     }
 

--- a/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosActionTask.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosActionTask.kt
@@ -86,8 +86,7 @@ class KronosActionTask {
             }
         } as List<KronosOperationResult>
         val affectRows = results.sumOf { it.affectedRows } //受影响的行数
-        val lastInsertId = results.mapNotNull { it.lastInsertId }.lastOrNull() //最后插入的id
-        return KronosOperationResult(affectRows, lastInsertId).apply {
+        return KronosOperationResult(affectRows).apply {
             afterExecute?.invoke(this, dataSource) //在执行之后执行的操作
         }
     }

--- a/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosActionTask.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosActionTask.kt
@@ -88,6 +88,7 @@ class KronosActionTask {
         val affectRows = results.sumOf { it.affectedRows } //受影响的行数
         return KronosOperationResult(affectRows).apply {
             afterExecute?.invoke(this, dataSource) //在执行之后执行的操作
+            stash.putAll(results.last().stash)
         }
     }
 
@@ -119,8 +120,9 @@ class KronosActionTask {
          * @return KronosActionTask returns a new KronosActionTask with all the atomic tasks from the list.
          */
         fun KronosAtomicActionTask.toKronosActionTask(): KronosActionTask {
-            return KronosActionTask().apply {
-                atomicTasks.addAll(trySplitOut())
+            return KronosActionTask().also {
+                it.atomicTasks.addAll(trySplitOut())
+                it.atomicTasks.forEach { task -> task.stash.putAll(stash) }
             }
         }
 

--- a/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosAtomicActionTask.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosAtomicActionTask.kt
@@ -40,10 +40,4 @@ data class KronosAtomicActionTask(
      * @return a pair of JDBC SQL and a list of JDBC parameter lists. If paramMapArr is null, an empty array is used.
      */
     override fun parsed() = parseSqlStatement(sql, paramMap)
-
-    fun trySplitOut(): List<KronosAtomicActionTask> {
-        return sql.split(";").map {
-            KronosAtomicActionTask(it.trim(), paramMap, operationType, stash)
-        }
-    }
 }

--- a/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosAtomicActionTask.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosAtomicActionTask.kt
@@ -31,7 +31,7 @@ data class KronosAtomicActionTask(
     override var sql: String,
     override val paramMap: Map<String, Any?> = mapOf(),
     override val operationType: KOperationType = KOperationType.UPDATE,
-    override val useIdentity: Boolean = false
+    override val stash: MutableMap<String, Any?> = mutableMapOf()
 ) : KAtomicActionTask {
 
     /**
@@ -43,7 +43,7 @@ data class KronosAtomicActionTask(
 
     fun trySplitOut(): List<KronosAtomicActionTask> {
         return sql.split(";").map {
-            KronosAtomicActionTask(it.trim(), paramMap, operationType, useIdentity)
+            KronosAtomicActionTask(it.trim(), paramMap, operationType, stash)
         }
     }
 }

--- a/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosAtomicBatchTask.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosAtomicBatchTask.kt
@@ -32,7 +32,7 @@ data class KronosAtomicBatchTask(
     override val sql: String,
     override val paramMapArr: Array<Map<String, Any?>>? = null,
     override val operationType: KOperationType = KOperationType.UPDATE,
-    override val useIdentity: Boolean = false
+    override val stash: MutableMap<String, Any?> = mutableMapOf()
 ) : KAtomicActionTask, KBatchTask {
 
     @Deprecated("Please use 'paramMapArr' instead.")

--- a/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosAtomicQueryTask.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosAtomicQueryTask.kt
@@ -31,7 +31,8 @@ import com.kotlinorm.interfaces.KAtomicQueryTask
 data class KronosAtomicQueryTask(
     override var sql: String,
     override val paramMap: Map<String, Any?> = mapOf(),
-    override val operationType: KOperationType = KOperationType.SELECT
+    override val operationType: KOperationType = KOperationType.SELECT,
+    val stash: MutableMap<String, Any?> = mutableMapOf()
 ) : KAtomicQueryTask {
 
     /**

--- a/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosOperationResult.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/KronosOperationResult.kt
@@ -22,9 +22,9 @@ package com.kotlinorm.beans.task
  * the result of operation
  *
  * @property affectedRows the number of affected rows
- * @property lastInsertId the last insert id
  */
 data class KronosOperationResult(
-    val affectedRows: Int = 0,
-    val lastInsertId: Long? = 0
-)
+    val affectedRows: Int = 0
+) {
+    val stash = mutableMapOf<String, Any?>() // 存储临时数据的map
+}

--- a/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/TasKEventRegister.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/TasKEventRegister.kt
@@ -1,24 +1,63 @@
+/**
+ * Copyright 2022-2024 kronos-orm
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.kotlinorm.beans.task
 
+import com.kotlinorm.beans.task.ActionEvent.afterActionEvents
+import com.kotlinorm.beans.task.ActionEvent.beforeActionEvents
 import com.kotlinorm.beans.task.QueryEvent.afterQueryEvents
 import com.kotlinorm.beans.task.QueryEvent.beforeQueryEvents
 import com.kotlinorm.interfaces.TaskEventPlugin
 import com.kotlinorm.types.ActionTaskEventList
 import com.kotlinorm.types.QueryTaskEventList
 
+/**
+ * Task Event Register
+ *
+ * Object to register task events
+ *
+ * @author OUSC
+ */
 object QueryEvent {
     val beforeQueryEvents: QueryTaskEventList = mutableListOf()
     val afterQueryEvents: QueryTaskEventList = mutableListOf()
 }
 
+/**
+ * Action Event Register
+ *
+ * Object to register action events
+ *
+ * @author OUSC
+ */
 object ActionEvent {
     val beforeActionEvents: ActionTaskEventList = mutableListOf()
     val afterActionEvents: ActionTaskEventList = mutableListOf()
 }
 
+/**
+ * Register Task Event Plugin
+ *
+ * Function to register task event plugin
+ *
+ * @param plugin the task event plugin
+ */
 fun registerTaskEventPlugin(plugin: TaskEventPlugin) {
     plugin.doBeforeQuery?.let { beforeQueryEvents.add(it) }
     plugin.doAfterQuery?.let { afterQueryEvents.add(it) }
-    plugin.doBeforeAction?.let { ActionEvent.beforeActionEvents.add(it) }
-    plugin.doAfterAction?.let { ActionEvent.afterActionEvents.add(it) }
+    plugin.doBeforeAction?.let { beforeActionEvents.add(it) }
+    plugin.doAfterAction?.let { afterActionEvents.add(it) }
 }

--- a/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/TasKEventRegister.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/beans/task/TasKEventRegister.kt
@@ -1,0 +1,24 @@
+package com.kotlinorm.beans.task
+
+import com.kotlinorm.beans.task.QueryEvent.afterQueryEvents
+import com.kotlinorm.beans.task.QueryEvent.beforeQueryEvents
+import com.kotlinorm.interfaces.TaskEventPlugin
+import com.kotlinorm.types.ActionTaskEventList
+import com.kotlinorm.types.QueryTaskEventList
+
+object QueryEvent {
+    val beforeQueryEvents: QueryTaskEventList = mutableListOf()
+    val afterQueryEvents: QueryTaskEventList = mutableListOf()
+}
+
+object ActionEvent {
+    val beforeActionEvents: ActionTaskEventList = mutableListOf()
+    val afterActionEvents: ActionTaskEventList = mutableListOf()
+}
+
+fun registerTaskEventPlugin(plugin: TaskEventPlugin) {
+    plugin.doBeforeQuery?.let { beforeQueryEvents.add(it) }
+    plugin.doAfterQuery?.let { afterQueryEvents.add(it) }
+    plugin.doBeforeAction?.let { ActionEvent.beforeActionEvents.add(it) }
+    plugin.doAfterAction?.let { ActionEvent.afterActionEvents.add(it) }
+}

--- a/kronos-core/src/main/kotlin/com/kotlinorm/enums/DBType.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/enums/DBType.kt
@@ -67,7 +67,8 @@ enum class DBType {
     /**
      * [GaussDB](https://www.huawei.com/en/psirt/security-advisories/huawei-sa-20210811-01-database-en) Database
      */
-    GaussDB;
+    GaussDB,
+    Unknown;
 
     companion object {
         /**

--- a/kronos-core/src/main/kotlin/com/kotlinorm/interfaces/KAtomicActionTask.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/interfaces/KAtomicActionTask.kt
@@ -24,5 +24,5 @@ package com.kotlinorm.interfaces
  * @author OUSC
  */
 interface KAtomicActionTask : KAtomicTask {
-    val useIdentity: Boolean
+    val stash: MutableMap<String, Any?>
 }

--- a/kronos-core/src/main/kotlin/com/kotlinorm/interfaces/KIdGenerator.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/interfaces/KIdGenerator.kt
@@ -1,5 +1,29 @@
+/**
+ * Copyright 2022-2024 kronos-orm
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.kotlinorm.interfaces
 
+/**
+ * KIdGenerator
+ *
+ * Interface for ID Generator
+ *
+ * @param T the type of ID
+ * @author OUSC
+ */
 interface KIdGenerator<T> {
     fun nextId(): T
 }

--- a/kronos-core/src/main/kotlin/com/kotlinorm/interfaces/TaskEventPlugin.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/interfaces/TaskEventPlugin.kt
@@ -1,0 +1,11 @@
+package com.kotlinorm.interfaces
+
+import com.kotlinorm.types.ActionTaskEvent
+import com.kotlinorm.types.QueryTaskEvent
+
+interface TaskEventPlugin {
+    val doBeforeQuery: QueryTaskEvent?
+    val doAfterQuery: QueryTaskEvent?
+    val doBeforeAction: ActionTaskEvent?
+    val doAfterAction: ActionTaskEvent?
+}

--- a/kronos-core/src/main/kotlin/com/kotlinorm/interfaces/TaskEventPlugin.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/interfaces/TaskEventPlugin.kt
@@ -1,8 +1,31 @@
+/**
+ * Copyright 2022-2024 kronos-orm
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.kotlinorm.interfaces
 
 import com.kotlinorm.types.ActionTaskEvent
 import com.kotlinorm.types.QueryTaskEvent
 
+/**
+ * Task Event Plugin
+ *
+ * Interface for Task Event Plugin
+ *
+ * @author OUSC
+ */
 interface TaskEventPlugin {
     val doBeforeQuery: QueryTaskEvent?
     val doAfterQuery: QueryTaskEvent?

--- a/kronos-core/src/main/kotlin/com/kotlinorm/interfaces/ValueTransformer.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/interfaces/ValueTransformer.kt
@@ -1,7 +1,29 @@
+/**
+ * Copyright 2022-2024 kronos-orm
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.kotlinorm.interfaces
 
 import kotlin.reflect.KClass
 
+/**
+ * ValueTransformer
+ *
+ * Interface for Value Transformer
+ *
+ * @author OUSC
+ */
 interface ValueTransformer {
     fun isMatch(targetKotlinType: String, superTypesOfValue: List<String>, kClassOfValue: KClass<*>): Boolean
 

--- a/kronos-core/src/main/kotlin/com/kotlinorm/orm/cascade/CascadeInsertClause.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/orm/cascade/CascadeInsertClause.kt
@@ -26,6 +26,7 @@ import com.kotlinorm.enums.PrimaryKeyType
 import com.kotlinorm.orm.cascade.NodeOfKPojo.Companion.toTreeNode
 import com.kotlinorm.orm.insert.insert
 import com.kotlinorm.plugins.LastInsertIdPlugin.lastInsertId
+import com.kotlinorm.plugins.LastInsertIdPlugin.withId
 import com.kotlinorm.utils.getTypeSafeValue
 
 /**
@@ -81,10 +82,10 @@ object CascadeInsertClause {
             val identity = kPojoPrimaryKeyCache[kPojo.kClass()].takeIf { it!!.primaryKey == PrimaryKeyType.IDENTITY } ?: return@toTreeNode // 若没有自增主键，直接返回
             if(insertIgnore) return@toTreeNode // 若有子节点提升到本节点的父节点，在此层级不需要执行插入操作，而是在insertIgnore为true的子节点的下一层级执行插入操作
             val lastInsertId = if (kPojo != pojo) { // 判断当前进行的插入操作是否为最外层的插入操作
-                kPojo.insert().cascade(enabled = false).execute(wrapper).lastInsertId // 若不是最外层的插入操作，执行当前任务，获取当前任务的执行结果
+                kPojo.insert().cascade(enabled = false).withId().execute(wrapper) // 若不是最外层的插入操作，执行当前任务，获取当前任务的执行结果
             } else {
-                operationResult.lastInsertId // 若是最外层的插入操作，直接获取当前任务的执行结果
-            }
+                operationResult // 若是最外层的插入操作，直接获取当前任务的执行结果
+            }.lastInsertId
             val propName = identity.name
             if (lastInsertId != null && lastInsertId != 0L && dataMap[propName] == null) { // 若自增主键值不为空且未被赋值
                 val typeSafeId =

--- a/kronos-core/src/main/kotlin/com/kotlinorm/orm/insert/InsertClause.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/orm/insert/InsertClause.kt
@@ -55,6 +55,7 @@ class InsertClause<T : KPojo>(val pojo: T) {
     private var optimisticStrategy = kPojoOptimisticLockCache[kClass]
     internal var allColumns = kPojoAllColumnsCache[kClass]!!
     private var cascadeEnabled = true
+    var stash = mutableMapOf<String, Any?>()
 
     /**
      * cascadeAllowed
@@ -144,7 +145,7 @@ class InsertClause<T : KPojo>(val pojo: T) {
                 sql,
                 paramMapNew,
                 operationType = KOperationType.INSERT,
-                useIdentity = useIdentity
+                stash = mutableMapOf("useIdentity" to useIdentity)
             )
         )
 

--- a/kronos-core/src/main/kotlin/com/kotlinorm/orm/insert/InsertClause.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/orm/insert/InsertClause.kt
@@ -95,6 +95,7 @@ class InsertClause<T : KPojo>(val pojo: T) {
             PrimaryKeyType.IDENTITY -> useIdentity = true
             else -> {}
         }
+        stash["useIdentity"] = true
         allColumns.forEach {
             if (it.defaultValue != null && paramMap[it.name] == null) {
                 paramMap[it.name] = it.defaultValue
@@ -145,7 +146,7 @@ class InsertClause<T : KPojo>(val pojo: T) {
                 sql,
                 paramMapNew,
                 operationType = KOperationType.INSERT,
-                stash = mutableMapOf("useIdentity" to useIdentity)
+                stash = stash
             )
         )
 

--- a/kronos-core/src/main/kotlin/com/kotlinorm/plugins/LastInsertIdPlugin.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/plugins/LastInsertIdPlugin.kt
@@ -42,11 +42,11 @@ object LastInsertIdPlugin : TaskEventPlugin {
 
     override val doAfterAction: ActionTaskEvent? = { wrapper ->
         if (operationType == KOperationType.INSERT &&
-            stash["queryId"] == true || (stash["queryId"] == null && enabled)
+            (stash["queryId"] == true || (stash["queryId"] == null && enabled))
             && stash["useIdentity"] == true // 目前仅支持自增主键
         ) {
-            this.stash["lastInsertId"] = (wrapper.orDefault().forObject(
-                KronosAtomicQueryTask(lastInsertIdObtainSql(wrapper.orDefault().dbType)),
+            stash["lastInsertId"] = (wrapper.forObject(
+                KronosAtomicQueryTask(lastInsertIdObtainSql(wrapper.dbType)),
                 kClass = Long::class,
                 false,
                 listOf()
@@ -54,7 +54,8 @@ object LastInsertIdPlugin : TaskEventPlugin {
         }
     }
 
-    fun InsertClause<*>.withId() {
+    fun InsertClause<*>.withId(): InsertClause<*> {
         stash["queryId"] = true
+        return this
     }
 }

--- a/kronos-core/src/main/kotlin/com/kotlinorm/plugins/LastInsertIdPlugin.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/plugins/LastInsertIdPlugin.kt
@@ -1,0 +1,60 @@
+package com.kotlinorm.plugins
+
+import com.kotlinorm.Kronos
+import com.kotlinorm.beans.task.KronosAtomicQueryTask
+import com.kotlinorm.beans.task.KronosOperationResult
+import com.kotlinorm.enums.DBType
+import com.kotlinorm.enums.KOperationType
+import com.kotlinorm.interfaces.TaskEventPlugin
+import com.kotlinorm.orm.insert.InsertClause
+import com.kotlinorm.types.ActionTaskEvent
+import com.kotlinorm.types.QueryTaskEvent
+import com.kotlinorm.utils.DataSourceUtil.orDefault
+
+object LastInsertIdPlugin : TaskEventPlugin {
+    var enabled = false
+    var Kronos.lastInsertId
+        set(value) {
+            enabled = value
+        }
+        get() = enabled
+
+    val KronosOperationResult.lastInsertId
+        get() = this.stash["lastInsertId"] as? Long
+
+    // Generates the SQL statement needed to obtain the last inserted ID based on the provided database type.
+    fun lastInsertIdObtainSql(dbType: DBType): String {
+        return when (dbType) {
+            DBType.Mysql, DBType.H2, DBType.OceanBase -> "SELECT LAST_INSERT_ID()"
+            DBType.Oracle -> "SELECT * FROM DUAL"
+            DBType.Mssql -> "SELECT SCOPE_IDENTITY()"
+            DBType.Postgres -> "SELECT LASTVAL()"
+            DBType.DB2 -> "SELECT IDENTITY_VAL_LOCAL() FROM SYSIBM.SYSDUMMY1"
+            DBType.Sybase -> "SELECT @@IDENTITY"
+            DBType.SQLite -> "SELECT last_insert_rowid()"
+            else -> throw UnsupportedOperationException("Unsupported database type: $dbType")
+        }
+    }
+
+    override val doBeforeQuery: QueryTaskEvent? = null
+    override val doAfterQuery: QueryTaskEvent? = null
+    override val doBeforeAction: ActionTaskEvent? = null
+
+    override val doAfterAction: ActionTaskEvent? = { wrapper ->
+        if (operationType == KOperationType.INSERT &&
+            stash["queryId"] == true || (stash["queryId"] == null && enabled)
+            && stash["useIdentity"] == true // 目前仅支持自增主键
+        ) {
+            this.stash["lastInsertId"] = (wrapper.orDefault().forObject(
+                KronosAtomicQueryTask(lastInsertIdObtainSql(wrapper.orDefault().dbType)),
+                kClass = Long::class,
+                false,
+                listOf()
+            ) ?: 0L) as Long
+        }
+    }
+
+    fun InsertClause<*>.withId() {
+        stash["queryId"] = true
+    }
+}

--- a/kronos-core/src/main/kotlin/com/kotlinorm/types/KTask.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/types/KTask.kt
@@ -1,0 +1,17 @@
+package com.kotlinorm.types
+
+import com.kotlinorm.interfaces.KAtomicActionTask
+import com.kotlinorm.interfaces.KAtomicQueryTask
+import com.kotlinorm.interfaces.KronosDataSourceWrapper
+
+typealias ActionTaskEvent = (KAtomicActionTask.(
+    wrapper: KronosDataSourceWrapper
+) -> Unit)
+
+typealias ActionTaskEventList = MutableList<ActionTaskEvent>
+
+typealias QueryTaskEvent = (KAtomicQueryTask.(
+    wrapper: KronosDataSourceWrapper
+) -> Unit)
+
+typealias QueryTaskEventList = MutableList<QueryTaskEvent>

--- a/kronos-core/src/main/kotlin/com/kotlinorm/utils/TaskUtil.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/utils/TaskUtil.kt
@@ -74,7 +74,10 @@ fun KAtomicActionTask.execute(wrapper: KronosDataSourceWrapper?): KronosOperatio
             }
         }
     }
-    return logAndReturn(KronosOperationResult(affectRows))
+    stash.putAll(task.stash)
+    return logAndReturn(KronosOperationResult(affectRows).apply {
+        stash.putAll(task.stash)
+    })
 }
 
 var handleLogResult: (task: KAtomicTask, result: Any?, queryType: QueryType?) -> Unit = { task, result, queryType ->

--- a/kronos-core/src/test/kotlin/com/kotlinorm/orm/union/MysqlUnionTest.kt
+++ b/kronos-core/src/test/kotlin/com/kotlinorm/orm/union/MysqlUnionTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertEquals
 
 class MysqlUnionTest {
     object UnionWrapper : SampleMysqlJdbcWrapper() {
-        var cursor = 0;
+        var cursor = 0
         override fun forList(task: KAtomicQueryTask): List<Map<String, Any>> {
             return when (cursor++) {
                 0 -> listOf(

--- a/kronos-core/src/test/kotlin/com/kotlinorm/plugins/LastInsertIdTest.kt
+++ b/kronos-core/src/test/kotlin/com/kotlinorm/plugins/LastInsertIdTest.kt
@@ -1,0 +1,37 @@
+package com.kotlinorm.plugins
+
+import com.kotlinorm.Kronos
+import com.kotlinorm.beans.task.KronosOperationResult
+import com.kotlinorm.enums.DBType
+import com.kotlinorm.orm.insert.InsertClause
+import com.kotlinorm.plugins.LastInsertIdPlugin.withId
+import com.kotlinorm.wrappers.SampleMysqlJdbcWrapper
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class LastInsertIdTest {
+    @Test
+    fun lastInsertIdObtainSqlReturnsCorrectSqlForSupportedDbTypes() {
+        assertEquals("SELECT LAST_INSERT_ID()", LastInsertIdPlugin.lastInsertIdObtainSql(DBType.Mysql))
+        assertEquals("SELECT LAST_INSERT_ID()", LastInsertIdPlugin.lastInsertIdObtainSql(DBType.H2))
+        assertEquals("SELECT LAST_INSERT_ID()", LastInsertIdPlugin.lastInsertIdObtainSql(DBType.OceanBase))
+        assertEquals("SELECT * FROM DUAL", LastInsertIdPlugin.lastInsertIdObtainSql(DBType.Oracle))
+        assertEquals("SELECT SCOPE_IDENTITY()", LastInsertIdPlugin.lastInsertIdObtainSql(DBType.Mssql))
+        assertEquals("SELECT LASTVAL()", LastInsertIdPlugin.lastInsertIdObtainSql(DBType.Postgres))
+        assertEquals(
+            "SELECT IDENTITY_VAL_LOCAL() FROM SYSIBM.SYSDUMMY1", LastInsertIdPlugin.lastInsertIdObtainSql(
+                DBType.DB2
+            )
+        )
+        assertEquals("SELECT @@IDENTITY", LastInsertIdPlugin.lastInsertIdObtainSql(DBType.Sybase))
+        assertEquals("SELECT last_insert_rowid()", LastInsertIdPlugin.lastInsertIdObtainSql(DBType.SQLite))
+    }
+
+    @Test
+    fun lastInsertIdObtainSqlThrowsExceptionForUnsupportedDbType() {
+        assertFailsWith<UnsupportedOperationException> { LastInsertIdPlugin.lastInsertIdObtainSql(DBType.Unknown) }
+    }
+}

--- a/kronos-testing/src/test/kotlin/com/kotlinorm/database/TableOperationMysql.kt
+++ b/kronos-testing/src/test/kotlin/com/kotlinorm/database/TableOperationMysql.kt
@@ -11,6 +11,7 @@ import com.kotlinorm.database.SqlManager.getTableColumns
 import com.kotlinorm.enums.DBType
 import com.kotlinorm.orm.database.table
 import com.kotlinorm.orm.insert.insert
+import com.kotlinorm.plugins.LastInsertIdPlugin.lastInsertId
 import org.apache.commons.dbcp2.BasicDataSource
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -172,7 +173,7 @@ class TableOperationMysql {
             username = "yf",
             gender = 93
         )
-        val (_, lastInsertId) = newUser.insert().execute()
+        val lastInsertId = newUser.insert().execute().lastInsertId
         assertEquals(528, lastInsertId, "自增主键值应为528")
     }
 

--- a/kronos-testing/src/test/kotlin/com/kotlinorm/database/TableOperationMysql.kt
+++ b/kronos-testing/src/test/kotlin/com/kotlinorm/database/TableOperationMysql.kt
@@ -12,6 +12,7 @@ import com.kotlinorm.enums.DBType
 import com.kotlinorm.orm.database.table
 import com.kotlinorm.orm.insert.insert
 import com.kotlinorm.plugins.LastInsertIdPlugin.lastInsertId
+import com.kotlinorm.plugins.LastInsertIdPlugin.withId
 import org.apache.commons.dbcp2.BasicDataSource
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -168,12 +169,13 @@ class TableOperationMysql {
     @Test
     fun testLastInsertId() {
         dataSource.table.syncTable(user)
+        dataSource.table.truncateTable(user)
         wrapper.execute("ALTER TABLE tb_user AUTO_INCREMENT = 528")
         val newUser = MysqlUser(
             username = "yf",
             gender = 93
         )
-        val lastInsertId = newUser.insert().execute().lastInsertId
+        val lastInsertId = newUser.insert().withId().execute().lastInsertId
         assertEquals(528, lastInsertId, "自增主键值应为528")
     }
 


### PR DESCRIPTION
- [feat] (Task): Refactor the task execution process to support event hooks, add QueryEvent and ActionEvent to support task event registration
- [feat] (Plugin): Add LastInsertIdPlugin to support obtaining the last inserted ID, fix the logic for obtaining the auto-increment primary key ID during insertion operations