### PR TITLE
[Table OP] feature-reactor-get-comment-function-name

### DIFF
--- a/kronos-core/src/main/kotlin/com/kotlinorm/database/SqlManager.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/database/SqlManager.kt
@@ -71,9 +71,9 @@ object SqlManager {
         dbType: DBType, tableName: String
     ) = dbType.dbSupport?.getTableDropSql(dbType, tableName) ?: throw UnsupportedDatabaseTypeException(dbType)
 
-    fun getTableComment(
+    fun getTableCommentSql(
         dataSource: KronosDataSourceWrapper
-    ) = dataSource.dbType.dbSupport?.getTableComment(dataSource.dbType) ?: throw UnsupportedDatabaseTypeException(
+    ) = dataSource.dbType.dbSupport?.getTableCommentSql(dataSource.dbType) ?: throw UnsupportedDatabaseTypeException(
         dataSource.dbType
     )
 

--- a/kronos-core/src/main/kotlin/com/kotlinorm/database/mssql/MssqlSupport.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/database/mssql/MssqlSupport.kt
@@ -159,7 +159,7 @@ object MssqlSupport : DatabasesSupport {
     override fun getTableDropSql(dbType: DBType, tableName: String) =
         "IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'$tableName') AND type in (N'U')) BEGIN DROP TABLE $tableName END"
 
-    override fun getTableComment(dbType: DBType): String =
+    override fun getTableCommentSql(dbType: DBType): String =
         "SELECT ep.value AS TABLE_COMMENT FROM sys.extended_properties ep WHERE ep.major_id = OBJECT_ID(:tableName) AND ep.minor_id = 0 AND ep.name = 'MS_Description'"
 
     override fun getTableColumns(dataSource: KronosDataSourceWrapper, tableName: String): List<Field> {

--- a/kronos-core/src/main/kotlin/com/kotlinorm/database/mysql/MysqlSupport.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/database/mysql/MysqlSupport.kt
@@ -187,7 +187,7 @@ object MysqlSupport : DatabasesSupport {
 
     override fun getTableDropSql(dbType: DBType, tableName: String) = "DROP TABLE IF EXISTS $tableName"
 
-    override fun getTableComment(dbType: DBType) =
+    override fun getTableCommentSql(dbType: DBType) =
         "SELECT `TABLE_COMMENT` FROM information_schema.TABLES WHERE TABLE_NAME = :tableName AND TABLE_SCHEMA = :dbName"
 
     override fun getTableColumns(dataSource: KronosDataSourceWrapper, tableName: String): List<Field> {

--- a/kronos-core/src/main/kotlin/com/kotlinorm/database/oracle/OracleSupport.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/database/oracle/OracleSupport.kt
@@ -218,7 +218,7 @@ object OracleSupport : DatabasesSupport {
             END;
         """.trimIndent()
 
-    override fun getTableComment(dbType: DBType): String =
+    override fun getTableCommentSql(dbType: DBType): String =
         "SELECT comments FROM all_tab_comments WHERE table_name = :tableName AND owner = :dbName"
 
     override fun getTableColumns(dataSource: KronosDataSourceWrapper, tableName: String): List<Field> {
@@ -430,6 +430,8 @@ object OracleSupport : DatabasesSupport {
             orderByClauseSql.orEmpty()
         }${
             paginationSql ?: limitSql ?: ""
+        }${
+            lockSql.orEmpty()
         }"
     }
 

--- a/kronos-core/src/main/kotlin/com/kotlinorm/database/postgres/PostgresqlSupport.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/database/postgres/PostgresqlSupport.kt
@@ -142,7 +142,7 @@ object PostgresqlSupport : DatabasesSupport {
 
     override fun getTableDropSql(dbType: DBType, tableName: String) = "DROP TABLE IF EXISTS $tableName"
 
-    override fun getTableComment(dbType: DBType) =
+    override fun getTableCommentSql(dbType: DBType) =
         "select cast(obj_description(relfilenode, 'pg_class') as varchar) as comment  from pg_class c  where relname = :tableName"
 
     override fun getIndexCreateSql(dbType: DBType, tableName: String, index: KTableIndex) =

--- a/kronos-core/src/main/kotlin/com/kotlinorm/database/sqlite/SqliteSupport.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/database/sqlite/SqliteSupport.kt
@@ -115,7 +115,7 @@ object SqliteSupport : DatabasesSupport {
 
     override fun getTableDropSql(dbType: DBType, tableName: String) = "DROP TABLE IF EXISTS $tableName"
 
-    override fun getTableComment(dbType: DBType) = ""
+    override fun getTableCommentSql(dbType: DBType) = ""
 
     override fun getTableColumns(dataSource: KronosDataSourceWrapper, tableName: String): List<Field> {
         fun extractNumberInParentheses(input: String): Pair<Int, Int> {

--- a/kronos-core/src/main/kotlin/com/kotlinorm/interfaces/DatabasesSupport.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/interfaces/DatabasesSupport.kt
@@ -66,7 +66,7 @@ interface DatabasesSupport {
         tableName: String
     ): String
 
-    fun getTableComment(
+    fun getTableCommentSql(
         dbType: DBType
     ): String
 

--- a/kronos-core/src/main/kotlin/com/kotlinorm/orm/ddl/TableOperationUtil.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/orm/ddl/TableOperationUtil.kt
@@ -7,7 +7,7 @@ import com.kotlinorm.beans.logging.KLogMessage.Companion.kMsgOf
 import com.kotlinorm.beans.task.KronosAtomicQueryTask
 import com.kotlinorm.database.SqlManager.columnCreateDefSql
 import com.kotlinorm.database.SqlManager.getDBNameFrom
-import com.kotlinorm.database.SqlManager.getTableComment
+import com.kotlinorm.database.SqlManager.getTableCommentSql
 import com.kotlinorm.database.SqlManager.getTableExistenceSql
 import com.kotlinorm.enums.ColorPrintCode
 import com.kotlinorm.enums.DBType
@@ -36,7 +36,7 @@ fun queryTableExistence(tableName: String, dataSource: KronosDataSourceWrapper):
 fun queryTableComment(tableName: String, dataSource: KronosDataSourceWrapper): String {
     return dataSource.forObject(
         KronosAtomicQueryTask(
-            getTableComment(dataSource),
+            getTableCommentSql(dataSource),
             mapOf(
                 "tableName" to tableName,
                 "dbName" to getDBNameFrom(dataSource)
@@ -149,7 +149,7 @@ fun moveColumn(
     var l = 0
     var r = size - 1
 
-    for (i in 0 until size) {
+    repeat(size) {
         // 正向查找向前移动的字段
         processLeft(filteredExpect, filteredCurrent, lFields, l)
         if (l < size) l++

--- a/kronos-testing/src/test/kotlin/com/kotlinorm/database/TableOperationMysql.kt
+++ b/kronos-testing/src/test/kotlin/com/kotlinorm/database/TableOperationMysql.kt
@@ -186,7 +186,7 @@ class TableOperationMysql {
         val comment = user.kronosTableComment()
         assertEquals("Kotlin Data Class for MysqlUser", comment, "表注释不正确")
         val realComment = wrapper.queryOne<String>(
-            SqlManager.getTableComment(wrapper),
+            SqlManager.getTableCommentSql(wrapper),
             mapOf(
                 "tableName" to user.kronosTableName(),
                 "dbName" to "kronos_testing"


### PR DESCRIPTION
- [fix] (Database support): Unified method name for retrieving table comments is `getTableCommentSql`

- [feat] (Testing): Updated test cases to adapt to the new table comment method name