### PR TITLE
fix(ci): fix bump-version.sh sed syntax for Linux

### DIFF
--- a/.github/scripts/bump-version.sh
+++ b/.github/scripts/bump-version.sh
@@ -45,12 +45,18 @@ incPatch() {
 setVersionInFiles() {
   local newv="$1"
   # publishing.gradle.kts
-  sed -i.bak -E "s/(project\.version\s*=\s*")[^"]+(".*)/\1${newv}\2/" "$PUBLISHING_KTS"
-  rm -f "$PUBLISHING_KTS.bak"
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' -E "s/(project\.version\s*=\s*\")[^\"]+(\".*)$/\1${newv}\2/" "$PUBLISHING_KTS"
+  else
+    sed -i -E "s/(project\.version\s*=\s*\")[^\"]+(\".*)$/\1${newv}\2/" "$PUBLISHING_KTS"
+  fi
 
   # KronosGradlePlugin.kt
-  sed -i.bak -E "s/(version\s*=\s*")[^"]+(".*)/\1${newv}\2/" "$PLUGIN_KT"
-  rm -f "$PLUGIN_KT.bak"
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' -E "s/(version\s*=\s*\")[^\"]+(\".*)$/\1${newv}\2/" "$PLUGIN_KT"
+  else
+    sed -i -E "s/(version\s*=\s*\")[^\"]+(\".*)$/\1${newv}\2/" "$PLUGIN_KT"
+  fi
 }
 
 cmd=${1:-}

--- a/README-zh_CN.MD
+++ b/README-zh_CN.MD
@@ -37,7 +37,7 @@ Kronos 是为 Kotlin 设计的现代 ORM 框架，基于编译器插件开发，
 [![CI](https://github.com/kronos-orm/kronos-orm/actions/workflows/kronos-testing.yml/badge.svg)](https://github.com/kronos-orm/kronos-orm/actions/workflows/kronos-testing.yml)
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.kotlinorm/kronos-core.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:com.kotlinorm)
-[![Maven Central Snapshots](https://img.shields.io/badge/Maven%20Central%20Snapshots-v0.0.6--SNAPSHOT-blue?link=https%3A%2F%2Fcentral.sonatype.com%2Fservice%2Frest%2Frepository%2Fbrowse%2Fmaven-snapshots%2Fcom%2Fkotlinorm%2F)](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/kotlinorm/)
+[![Maven Central Snapshots](https://img.shields.io/badge/Maven%20Central%20Snapshots-v0.0.7--SNAPSHOT-blue?link=https%3A%2F%2Fcentral.sonatype.com%2Fservice%2Frest%2Frepository%2Fbrowse%2Fmaven-snapshots%2Fcom%2Fkotlinorm%2F)](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/kotlinorm/)
 
 [官网](https://www.kotlinorm.com) | [中文文档](https://kotlinorm.com/#/documentation/zh-CN/getting-started/quick-start) | [Discord](https://discord.gg/Vn8EzxRX) | [QQ群](https://qm.qq.com/q/V821JzFUcM)
 </div>

--- a/README.MD
+++ b/README.MD
@@ -37,7 +37,7 @@ Based on the KCP implementation of expression tree parsing and concatenation, Kr
 [![CI](https://github.com/kronos-orm/kronos-orm/actions/workflows/kronos-testing.yml/badge.svg)](https://github.com/kronos-orm/kronos-orm/actions/workflows/kronos-testing.yml)
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.kotlinorm/kronos-core.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:com.kotlinorm)
-[![Maven Central Snapshots](https://img.shields.io/badge/Maven%20Central%20Snapshots-v0.0.6--SNAPSHOT-blue?link=https%3A%2F%2Fcentral.sonatype.com%2Fservice%2Frest%2Frepository%2Fbrowse%2Fmaven-snapshots%2Fcom%2Fkotlinorm%2F)](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/kotlinorm/)
+[![Maven Central Snapshots](https://img.shields.io/badge/Maven%20Central%20Snapshots-v0.0.7--SNAPSHOT-blue?link=https%3A%2F%2Fcentral.sonatype.com%2Fservice%2Frest%2Frepository%2Fbrowse%2Fmaven-snapshots%2Fcom%2Fkotlinorm%2F)](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/kotlinorm/)
 
 [Official Website](https://www.kotlinorm.com) | [Documentation](https://kotlinorm.com/#/documentation/en/getting-started/quick-start) | [Getting Started (Repo)](./develop-docs/getting-started.md) | [Discord](https://discord.gg/Vn8EzxRX) | [QQ群](https://qm.qq.com/q/V821JzFUcM)
 </div>

--- a/build-logic/src/main/kotlin/publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/publishing.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 value class PublishConfiguration(val project: Project) {
     init {
         project.group = "com.kotlinorm"
-        project.version = "0.0.6"
+        project.version = "0.0.7-SNAPSHOT"
         project.description = when (project.name) {
             "kronos-core" -> "Kronos is an easy-to-use, flexible, lightweight ORM framework designed for kotlin. Kronos core is the core module of Kronos, which provides basic ORM functions."
             "kronos-jdbc-wrapper" -> "Kronos 's built-in database operation plug-in based on the original jdbc supports variable templates and multiple databases."

--- a/kronos-gradle-plugin/src/main/kotlin/com/kotlinorm/compiler/plugin/KronosGradlePlugin.kt
+++ b/kronos-gradle-plugin/src/main/kotlin/com/kotlinorm/compiler/plugin/KronosGradlePlugin.kt
@@ -36,7 +36,7 @@ class KronosGradlePlugin : KotlinCompilerPluginSupportPlugin {
         pluginId = "com.kotlinorm.kronos-compiler-gradle-plugin"
         group = "com.kotlinorm"
         artifactId = "kronos-compiler-plugin"
-        version = "0.0.6"
+        version = "0.0.7-SNAPSHOT"
     }
 
     override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {


### PR DESCRIPTION
The sed -i.bak syntax causes syntax errors on Linux (GitHub Actions). Changed to use OS-specific sed syntax:
- macOS: sed -i '' -E
- Linux: sed -i -E

This fixes the 'syntax error near unexpected token' error in the release workflow when bumping to next SNAPSHOT version.

# Pull Request / 合并请求

Thank you for contributing to Kronos ORM! 请按模板填写，便于快速评审。

## Summary / 摘要
Describe what this PR does. 简述本 PR 做了什么。

## Related Issue(s) / 关联问题
- Closes #
- Relates to #

## Type of change / 变更类型
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / Optimization
- [ ] Documentation
- [ ] Test only / CI

## Affected module(s) / 影响模块
- [ ] kronos-core
- [ ] kronos-logging
- [ ] kronos-jdbc-wrapper
- [ ] kronos-codegen
- [ ] kronos-compiler-plugin
- [ ] build plugin(s)

## How has this been tested? / 测试说明
- [ ] Unit tests added / updated
- [ ] Manual verification
- [ ] Covers edge cases mentioned in issue

Please include:
- Kotlin version / Gradle version
- DB type(s) tested (e.g., MYSQL, POSTGRESQL)
- Logs or screenshots if relevant

```kotlin
// key test or usage snippet
```

## Documentation / 文档
- [ ] Not needed
- [ ] Added/updated docs under develop-docs
- [ ] Updated README(s)

## Backward compatibility / 兼容性
- Breaking changes? If yes, describe migration path. 是否存在破坏性变更，如有请描述迁移路径。

## Checklist / 提交前检查
- [ ] I have read CONTRIBUTING.md / 我已阅读贡献指南
- [ ] I added tests that prove my fix/feature works / 我已补充或更新测试
- [ ] I updated documentation where necessary / 我已更新必要文档
- [ ] I linked related issues (e.g., "Closes #123") / 我已关联相关 Issue
- [ ] I ran detekt/formatting (if applicable) / 我已本地通过静态检查

---
References:
- CONTRIBUTING: ./CONTRIBUTING.md
- Code of Conduct: ./CODE_OF_CONDUCT.md
- Developer Docs: ./develop-docs
