### PR TITLE
ci: open PR for next snapshot bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   publish:
@@ -72,13 +73,22 @@ jobs:
         run: |
           bash ./gradlew --no-daemon clean publishAllToMavenCentral -x test
 
-      - name: Release 🔼 - bump to next SNAPSHOT and push
+      - name: Release 🔼 - open next SNAPSHOT PR
         if: steps.detect.outputs.mode == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           NEXT_SNAPSHOT=$( bash .github/scripts/bump-version.sh next-snapshot | tail -n1 | cut -d= -f2 )
+          BRANCH_NAME="chore/next-snapshot-${NEXT_SNAPSHOT%-SNAPSHOT}"
+          git switch -c "$BRANCH_NAME"
           git add -A
           git commit -m "chore(version): start $NEXT_SNAPSHOT [skip ci]" || echo "No changes to commit"
-          git push origin HEAD:${{ github.event.pull_request.base.ref }}
+          git push origin "$BRANCH_NAME"
+          gh pr create \
+            --base "${{ github.event.pull_request.base.ref }}" \
+            --head "$BRANCH_NAME" \
+            --title "chore(version): start $NEXT_SNAPSHOT" \
+            --body "Start the next development cycle after publishing ${{ steps.release_set.outputs.version }} by bumping release configuration to $NEXT_SNAPSHOT."
 
       - name: Snapshot 📸 - publish to Central Snapshots
         if: steps.detect.outputs.mode == 'snapshot'


### PR DESCRIPTION
# Pull Request / 合并请求

## Summary / 摘要
Fix the release workflow so the post-release next snapshot bump opens a PR instead of pushing directly to protected `main`.

This avoids repository rule violations such as required checks blocking direct pushes after Maven Central publication succeeds.

## Related Issue(s) / 关联问题
- Relates to #210
- Relates to #212

## Type of change / 变更类型
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / Optimization
- [ ] Documentation
- [x] Test only / CI

## Affected module(s) / 影响模块
- [ ] kronos-core
- [ ] kronos-logging
- [ ] kronos-jdbc-wrapper
- [ ] kronos-codegen
- [ ] kronos-compiler-plugin
- [x] build plugin(s)

## How has this been tested? / 测试说明
- [ ] Unit tests added / updated
- [x] Manual verification
- [x] Covers edge cases mentioned in issue

Please include:
- Kotlin version / Gradle version: Not applicable
- DB type(s) tested: Not applicable
- Logs or screenshots if relevant: The previous release run published to Maven Central successfully, then failed on the direct `git push origin HEAD:main` due to required checks.

```kotlin
// Not applicable: GitHub Actions workflow-only change.
```

## Documentation / 文档
- [x] Not needed
- [ ] Added/updated docs under develop-docs
- [ ] Updated README(s)

## Backward compatibility / 兼容性
No runtime compatibility impact. Release automation now respects branch protection by creating a PR for the next snapshot bump.

## Checklist / 提交前检查
- [x] I have read CONTRIBUTING.md / 我已阅读贡献指南
- [ ] I added tests that prove my fix/feature works / 我已补充或更新测试
- [ ] I updated documentation where necessary / 我已更新必要文档
- [x] I linked related issues (e.g., "Closes #123") / 我已关联相关 Issue
- [x] I ran detekt/formatting (if applicable) / 我已本地通过静态检查