### PR TITLE
fix(gradle): wire generated service into sources jar

### DIFF
--- a/kronos-gradle-plugin/src/main/kotlin/com/kotlinorm/compiler/plugin/KronosGradlePlugin.kt
+++ b/kronos-gradle-plugin/src/main/kotlin/com/kotlinorm/compiler/plugin/KronosGradlePlugin.kt
@@ -107,6 +107,9 @@ class KronosGradlePlugin : KotlinCompilerPluginSupportPlugin {
                         processResourcesTask.dependsOn(task)
                     }
                 }
+            target.tasks.matching { it.name == "sourcesJar" }.configureEach { sourcesJar ->
+                sourcesJar.dependsOn(task)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Make sourcesJar depend on generateKronosKPojoFactoryService when the Kronos Gradle plugin adds the generated service directory to main resources.
- Fixes the Gradle 9.6.1 implicit dependency failure seen in publish run 28942368106.

## Verification
- git diff --check
- ./gradlew.bat --no-daemon :kronos-core:sourcesJar -x test --console=plain