### PR TITLE
fix(build): allow docs deployment on newer JDKs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,9 +47,6 @@ allprojects {
 
     plugins.withType<JavaPlugin> {
         extensions.configure<JavaPluginExtension> {
-            toolchain {
-                languageVersion.set(JavaLanguageVersion.of(17))
-            }
             sourceCompatibility = JavaVersion.VERSION_1_8
             targetCompatibility = JavaVersion.VERSION_1_8
         }

--- a/kronos-gradle-plugin/build.gradle.kts
+++ b/kronos-gradle-plugin/build.gradle.kts
@@ -11,9 +11,6 @@ dependencies {
 }
 
 java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-    }
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
 }


### PR DESCRIPTION
## Summary
- Remove exact Gradle Java toolchain selection for JDK 17 from the root build and the included Gradle plugin build.
- Keep Java and Kotlin bytecode targets unchanged, so artifacts remain Java 8 compatible.
- Allows Cloudflare docs deployment to use the bootstrapped JDK 21 instead of failing while searching for a JDK 17 installation.

## Verification
- git diff --check
- Confirmed no remaining exact JDK 17 toolchain declarations in Gradle scripts.

Note: local Dokka/help Gradle runs timed out in this shell before completion; no Gradle toolchain validation error was observed before timeout.