### PR TITLE
fix syncTable custom primary key column diff

### DIFF
--- a/kronos-core/src/main/kotlin/com/kotlinorm/database/DatabaseStatementBuilders.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/database/DatabaseStatementBuilders.kt
@@ -60,7 +60,7 @@ internal fun Field.sameDefinitionAs(other: Field): Boolean =
         length == other.length &&
         scale == other.scale &&
         nullable == other.nullable &&
-        primaryKey == other.primaryKey &&
+        primaryKey.sameDatabasePrimaryKeyModeAs(other.primaryKey) &&
         defaultValue.orEmpty() == other.defaultValue.orEmpty() &&
         kDoc.orEmpty() == other.kDoc.orEmpty()
 
@@ -69,19 +69,32 @@ internal fun Field.sameDefinitionAs(other: Field, dbType: DBType): Boolean =
         DBType.SQLite -> {
             sqliteStorageClass(type) == sqliteStorageClass(other.type) &&
                 nullable == other.nullable &&
-                primaryKey == other.primaryKey &&
+                primaryKey.sameDatabasePrimaryKeyModeAs(other.primaryKey) &&
                 defaultValue.orEmpty() == other.defaultValue.orEmpty()
         }
 
         DBType.Oracle -> {
             oracleEquivalentType(type, length, scale, other.type, other.length, other.scale) &&
                 nullable == other.nullable &&
-                primaryKey == other.primaryKey &&
+                primaryKey.sameDatabasePrimaryKeyModeAs(other.primaryKey) &&
                 defaultValue.orEmpty() == other.defaultValue.orEmpty() &&
                 kDoc.orEmpty() == other.kDoc.orEmpty()
         }
 
         else -> sameDefinitionAs(other)
+    }
+
+private fun PrimaryKeyType.sameDatabasePrimaryKeyModeAs(other: PrimaryKeyType): Boolean =
+    databasePrimaryKeyMode() == other.databasePrimaryKeyMode()
+
+private fun PrimaryKeyType.databasePrimaryKeyMode(): String =
+    when (this) {
+        PrimaryKeyType.NOT -> "none"
+        PrimaryKeyType.IDENTITY -> "identity"
+        PrimaryKeyType.DEFAULT,
+        PrimaryKeyType.UUID,
+        PrimaryKeyType.SNOWFLAKE,
+        PrimaryKeyType.CUSTOM -> "primary"
     }
 
 private fun sqliteStorageClass(type: KColumnType): String = when (type) {

--- a/kronos-core/src/main/kotlin/com/kotlinorm/orm/ddl/TableOperationUtil.kt
+++ b/kronos-core/src/main/kotlin/com/kotlinorm/orm/ddl/TableOperationUtil.kt
@@ -122,7 +122,7 @@ fun columnDiffer(
         } else null
     }
 
-    val need2Move = moveColumn(expect, current)
+    val need2Move = if (dbType == DBType.SQLite) emptyList() else moveColumn(expect, current)
     val toModified = expect.mapIndexedNotNull { index, col ->
         val tableColumn = currentByName[col.columnName.columnKey()]
         if (tableColumn != null && (!col.sameDefinitionAs(tableColumn, dbType) || col.columnName in need2Move)

--- a/kronos-core/src/test/kotlin/com/kotlinorm/orm/ddl/TableOperationUtilTest.kt
+++ b/kronos-core/src/test/kotlin/com/kotlinorm/orm/ddl/TableOperationUtilTest.kt
@@ -104,6 +104,29 @@ class TableOperationUtilTest {
     }
 
     @Test
+    fun `column differ ignores sqlite column order after appended add column`() {
+        val expected = listOf(
+            field("id", KColumnType.VARCHAR, length = 64, primaryKey = PrimaryKeyType.CUSTOM, nullable = false),
+            field("name", KColumnType.VARCHAR, length = 80),
+            field("age", KColumnType.BIGINT),
+            field("create_time", KColumnType.DATETIME),
+            field("update_time", KColumnType.DATETIME)
+        )
+        val current = listOf(
+            field("id", KColumnType.TEXT, primaryKey = PrimaryKeyType.DEFAULT, nullable = false),
+            field("name", KColumnType.TEXT),
+            field("create_time", KColumnType.TEXT),
+            field("update_time", KColumnType.TEXT),
+            field("age", KColumnType.INT)
+        )
+
+        assertEquals(
+            TableColumnDiff(toAdd = emptyList(), toModified = emptyList(), toDelete = emptyList()),
+            columnDiffer(DBType.SQLite, expected, current)
+        )
+    }
+
+    @Test
     fun `column differ matches oracle metadata columns case insensitively`() {
         val expected = listOf(
             field("id", KColumnType.INT, nullable = false),
@@ -137,6 +160,39 @@ class TableOperationUtilTest {
             TableColumnDiff(toAdd = emptyList(), toModified = emptyList(), toDelete = emptyList()),
             columnDiffer(DBType.Oracle, expected, current)
         )
+    }
+
+    @Test
+    fun `column differ treats generated and custom primary keys as database primary keys`() {
+        val dbTypes = listOf(DBType.Mysql, DBType.Postgres, DBType.SQLite, DBType.Mssql, DBType.Oracle)
+
+        dbTypes.forEach { dbType ->
+            val expected = listOf(
+                field("id", KColumnType.VARCHAR, length = 64, primaryKey = PrimaryKeyType.CUSTOM, nullable = false),
+                field("name", KColumnType.VARCHAR, length = 80),
+                field("age", KColumnType.BIGINT),
+                field("create_time", KColumnType.DATETIME),
+                field("update_time", KColumnType.DATETIME)
+            )
+            val current = listOf(
+                field(
+                    if (dbType == DBType.Oracle) "ID" else "id",
+                    KColumnType.VARCHAR,
+                    length = 64,
+                    primaryKey = PrimaryKeyType.DEFAULT,
+                    nullable = false
+                ),
+                field(if (dbType == DBType.Oracle) "NAME" else "name", KColumnType.VARCHAR, length = 80),
+                field(if (dbType == DBType.Oracle) "CREATE_TIME" else "create_time", KColumnType.DATETIME),
+                field(if (dbType == DBType.Oracle) "UPDATE_TIME" else "update_time", KColumnType.DATETIME)
+            )
+
+            val diff = columnDiffer(dbType, expected, current)
+
+            assertEquals(listOf(expected[2] to expected[1]), diff.toAdd, "toAdd for $dbType")
+            assertEquals(emptyList(), diff.toModified, "toModified for $dbType")
+            assertEquals(emptyList(), diff.toDelete, "toDelete for $dbType")
+        }
     }
 
     @Test

--- a/kronos-testing/src/test/kotlin/com/kotlinorm/integration/MysqlIntegrationTest.kt
+++ b/kronos-testing/src/test/kotlin/com/kotlinorm/integration/MysqlIntegrationTest.kt
@@ -9,6 +9,7 @@ import com.kotlinorm.integration.suites.ErrorIntegrationSuite
 import com.kotlinorm.integration.suites.FunctionAndParameterIntegrationSuite
 import com.kotlinorm.integration.suites.QueryIntegrationSuite
 import com.kotlinorm.integration.suites.SchemaIntegrationSuite
+import com.kotlinorm.integration.suites.SchemaSyncRegressionSuite
 import com.kotlinorm.integration.suites.TransactionIntegrationSuite
 import com.kotlinorm.integration.suites.UpsertIntegrationSuite
 import com.kotlinorm.integration.suites.ValueTypeIntegrationSuite
@@ -16,6 +17,7 @@ import com.kotlinorm.integration.suites.WrapperSqlIntegrationSuite
 import com.kotlinorm.integration.support.IntegrationDatabaseEnvironments.mysql
 
 class MysqlSchemaIntegrationTest : SchemaIntegrationSuite(mysql, StandardIntegrationScenarioProfile)
+class MysqlSchemaSyncRegressionTest : SchemaSyncRegressionSuite(mysql, StandardIntegrationScenarioProfile)
 class MysqlCrudWhereIntegrationTest : CrudWhereIntegrationSuite(mysql, StandardIntegrationScenarioProfile)
 class MysqlQueryIntegrationTest : QueryIntegrationSuite(mysql, StandardIntegrationScenarioProfile)
 class MysqlDmlSubqueryIntegrationTest : DmlSubqueryIntegrationSuite(mysql, StandardIntegrationScenarioProfile)

--- a/kronos-testing/src/test/kotlin/com/kotlinorm/integration/OracleIntegrationTest.kt
+++ b/kronos-testing/src/test/kotlin/com/kotlinorm/integration/OracleIntegrationTest.kt
@@ -8,6 +8,7 @@ import com.kotlinorm.integration.suites.ErrorIntegrationSuite
 import com.kotlinorm.integration.suites.FunctionAndParameterIntegrationSuite
 import com.kotlinorm.integration.suites.QueryIntegrationSuite
 import com.kotlinorm.integration.suites.SchemaIntegrationSuite
+import com.kotlinorm.integration.suites.SchemaSyncRegressionSuite
 import com.kotlinorm.integration.suites.TransactionIntegrationSuite
 import com.kotlinorm.integration.suites.UpsertIntegrationSuite
 import com.kotlinorm.integration.suites.ValueTypeIntegrationSuite
@@ -15,6 +16,7 @@ import com.kotlinorm.integration.suites.WrapperSqlIntegrationSuite
 import com.kotlinorm.integration.support.IntegrationDatabaseEnvironments.oracle
 
 class OracleSchemaIntegrationTest : SchemaIntegrationSuite(oracle, StandardIntegrationScenarioProfile)
+class OracleSchemaSyncRegressionTest : SchemaSyncRegressionSuite(oracle, StandardIntegrationScenarioProfile)
 class OracleCrudWhereIntegrationTest : CrudWhereIntegrationSuite(oracle, StandardIntegrationScenarioProfile)
 class OracleQueryIntegrationTest : QueryIntegrationSuite(oracle, StandardIntegrationScenarioProfile)
 class OracleDmlSubqueryIntegrationTest : DmlSubqueryIntegrationSuite(oracle, StandardIntegrationScenarioProfile)

--- a/kronos-testing/src/test/kotlin/com/kotlinorm/integration/PostgresIntegrationTest.kt
+++ b/kronos-testing/src/test/kotlin/com/kotlinorm/integration/PostgresIntegrationTest.kt
@@ -8,6 +8,7 @@ import com.kotlinorm.integration.suites.ErrorIntegrationSuite
 import com.kotlinorm.integration.suites.FunctionAndParameterIntegrationSuite
 import com.kotlinorm.integration.suites.QueryIntegrationSuite
 import com.kotlinorm.integration.suites.SchemaIntegrationSuite
+import com.kotlinorm.integration.suites.SchemaSyncRegressionSuite
 import com.kotlinorm.integration.suites.TransactionIntegrationSuite
 import com.kotlinorm.integration.suites.UpsertIntegrationSuite
 import com.kotlinorm.integration.suites.ValueTypeIntegrationSuite
@@ -15,6 +16,7 @@ import com.kotlinorm.integration.suites.WrapperSqlIntegrationSuite
 import com.kotlinorm.integration.support.IntegrationDatabaseEnvironments.postgres
 
 class PostgresSchemaIntegrationTest : SchemaIntegrationSuite(postgres, StandardIntegrationScenarioProfile)
+class PostgresSchemaSyncRegressionTest : SchemaSyncRegressionSuite(postgres, StandardIntegrationScenarioProfile)
 class PostgresCrudWhereIntegrationTest : CrudWhereIntegrationSuite(postgres, StandardIntegrationScenarioProfile)
 class PostgresQueryIntegrationTest : QueryIntegrationSuite(postgres, StandardIntegrationScenarioProfile)
 class PostgresDmlSubqueryIntegrationTest : DmlSubqueryIntegrationSuite(postgres, StandardIntegrationScenarioProfile)

--- a/kronos-testing/src/test/kotlin/com/kotlinorm/integration/SqlServerIntegrationTest.kt
+++ b/kronos-testing/src/test/kotlin/com/kotlinorm/integration/SqlServerIntegrationTest.kt
@@ -8,6 +8,7 @@ import com.kotlinorm.integration.suites.ErrorIntegrationSuite
 import com.kotlinorm.integration.suites.FunctionAndParameterIntegrationSuite
 import com.kotlinorm.integration.suites.QueryIntegrationSuite
 import com.kotlinorm.integration.suites.SchemaIntegrationSuite
+import com.kotlinorm.integration.suites.SchemaSyncRegressionSuite
 import com.kotlinorm.integration.suites.TransactionIntegrationSuite
 import com.kotlinorm.integration.suites.UpsertIntegrationSuite
 import com.kotlinorm.integration.suites.ValueTypeIntegrationSuite
@@ -15,6 +16,7 @@ import com.kotlinorm.integration.suites.WrapperSqlIntegrationSuite
 import com.kotlinorm.integration.support.IntegrationDatabaseEnvironments.sqlServer
 
 class SqlServerSchemaIntegrationTest : SchemaIntegrationSuite(sqlServer, StandardIntegrationScenarioProfile)
+class SqlServerSchemaSyncRegressionTest : SchemaSyncRegressionSuite(sqlServer, StandardIntegrationScenarioProfile)
 class SqlServerCrudWhereIntegrationTest : CrudWhereIntegrationSuite(sqlServer, StandardIntegrationScenarioProfile)
 class SqlServerQueryIntegrationTest : QueryIntegrationSuite(sqlServer, StandardIntegrationScenarioProfile)
 class SqlServerDmlSubqueryIntegrationTest : DmlSubqueryIntegrationSuite(sqlServer, StandardIntegrationScenarioProfile)

--- a/kronos-testing/src/test/kotlin/com/kotlinorm/integration/SqliteIntegrationTest.kt
+++ b/kronos-testing/src/test/kotlin/com/kotlinorm/integration/SqliteIntegrationTest.kt
@@ -8,6 +8,7 @@ import com.kotlinorm.integration.suites.ErrorIntegrationSuite
 import com.kotlinorm.integration.suites.FunctionAndParameterIntegrationSuite
 import com.kotlinorm.integration.suites.QueryIntegrationSuite
 import com.kotlinorm.integration.suites.SchemaIntegrationSuite
+import com.kotlinorm.integration.suites.SchemaSyncRegressionSuite
 import com.kotlinorm.integration.suites.TransactionIntegrationSuite
 import com.kotlinorm.integration.suites.UpsertIntegrationSuite
 import com.kotlinorm.integration.suites.ValueTypeIntegrationSuite
@@ -15,6 +16,7 @@ import com.kotlinorm.integration.suites.WrapperSqlIntegrationSuite
 import com.kotlinorm.integration.support.IntegrationDatabaseEnvironments.sqlite
 
 class SqliteSchemaIntegrationTest : SchemaIntegrationSuite(sqlite, StandardIntegrationScenarioProfile)
+class SqliteSchemaSyncRegressionTest : SchemaSyncRegressionSuite(sqlite, StandardIntegrationScenarioProfile)
 class SqliteCrudWhereIntegrationTest : CrudWhereIntegrationSuite(sqlite, StandardIntegrationScenarioProfile)
 class SqliteQueryIntegrationTest : QueryIntegrationSuite(sqlite, StandardIntegrationScenarioProfile)
 class SqliteDmlSubqueryIntegrationTest : DmlSubqueryIntegrationSuite(sqlite, StandardIntegrationScenarioProfile)

--- a/kronos-testing/src/test/kotlin/com/kotlinorm/integration/fixtures/SchemaSyncEntities.kt
+++ b/kronos-testing/src/test/kotlin/com/kotlinorm/integration/fixtures/SchemaSyncEntities.kt
@@ -1,0 +1,44 @@
+package com.kotlinorm.integration.fixtures
+
+import com.kotlinorm.annotations.ColumnType
+import com.kotlinorm.annotations.CreateTime
+import com.kotlinorm.annotations.PrimaryKey
+import com.kotlinorm.annotations.Table
+import com.kotlinorm.annotations.UpdateTime
+import com.kotlinorm.enums.KColumnType.BIGINT
+import com.kotlinorm.enums.KColumnType.DATETIME
+import com.kotlinorm.enums.KColumnType.VARCHAR
+import com.kotlinorm.interfaces.KPojo
+import java.time.LocalDateTime
+
+@Table("kt_schema_sync_user")
+data class SchemaSyncUserV1(
+    @PrimaryKey(custom = true)
+    @ColumnType(VARCHAR, 64)
+    var id: String? = null,
+    @ColumnType(VARCHAR, 80)
+    var name: String? = null,
+    @CreateTime
+    @ColumnType(DATETIME)
+    var createTime: LocalDateTime? = null,
+    @UpdateTime
+    @ColumnType(DATETIME)
+    var updateTime: LocalDateTime? = null,
+) : KPojo
+
+@Table("kt_schema_sync_user")
+data class SchemaSyncUserV2(
+    @PrimaryKey(custom = true)
+    @ColumnType(VARCHAR, 64)
+    var id: String? = null,
+    @ColumnType(VARCHAR, 80)
+    var name: String? = null,
+    @ColumnType(BIGINT)
+    var age: Long? = null,
+    @CreateTime
+    @ColumnType(DATETIME)
+    var createTime: LocalDateTime? = null,
+    @UpdateTime
+    @ColumnType(DATETIME)
+    var updateTime: LocalDateTime? = null,
+) : KPojo

--- a/kronos-testing/src/test/kotlin/com/kotlinorm/integration/suites/SchemaSyncRegressionSuite.kt
+++ b/kronos-testing/src/test/kotlin/com/kotlinorm/integration/suites/SchemaSyncRegressionSuite.kt
@@ -1,0 +1,45 @@
+package com.kotlinorm.integration.suites
+
+import com.kotlinorm.enums.KColumnType
+import com.kotlinorm.enums.DBType
+import com.kotlinorm.enums.PrimaryKeyType
+import com.kotlinorm.integration.fixtures.SchemaSyncUserV1
+import com.kotlinorm.integration.fixtures.SchemaSyncUserV2
+import com.kotlinorm.integration.profiles.IntegrationScenarioProfile
+import com.kotlinorm.integration.support.IntegrationDatabaseEnvironment
+import com.kotlinorm.integration.support.IntegrationSuiteSupport
+import com.kotlinorm.orm.ddl.queryTableColumns
+import com.kotlinorm.orm.ddl.table
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+abstract class SchemaSyncRegressionSuite(
+    environment: IntegrationDatabaseEnvironment,
+    profile: IntegrationScenarioProfile,
+) : IntegrationSuiteSupport(environment, profile) {
+    @Test
+    fun syncTableAddsColumnAfterCustomStringPrimaryKeyAndTimestampColumns() {
+        assumeDatabaseAvailable()
+        configureKronos()
+
+        wrapper.table.dropTable(SchemaSyncUserV1())
+        wrapper.table.createTable(SchemaSyncUserV1())
+
+        val existing = wrapper.table.syncTable(SchemaSyncUserV2())
+        val existingAfterSecondSync = wrapper.table.syncTable(SchemaSyncUserV2())
+
+        assertTrue(existing)
+        assertTrue(existingAfterSecondSync)
+        val columns = queryTableColumns("kt_schema_sync_user", wrapper)
+        val columnNames = columns.map { it.columnName.lowercase() }.toSet()
+        val age = columns.single { it.columnName.equals("age", ignoreCase = true) }
+        val id = columns.single { it.columnName.equals("id", ignoreCase = true) }
+
+        assertEquals(setOf("id", "name", "age", "create_time", "update_time"), columnNames)
+        assertEquals(if (wrapper.dbType == DBType.SQLite) KColumnType.INT else KColumnType.BIGINT, age.type)
+        assertEquals(true, age.nullable)
+        assertEquals(PrimaryKeyType.NOT, age.primaryKey)
+        assertTrue(id.primaryKey != PrimaryKeyType.NOT)
+    }
+}


### PR DESCRIPTION
## Summary
- normalize generated/custom primary-key strategies when comparing database column metadata
- ignore SQLite column-order-only diffs after ADD COLUMN, since SQLite appends columns and does not support ALTER COLUMN
- add schema sync regression coverage for custom string primary key + newly added ge column across all integration database test entrypoints

## Test matrix
- Core columnDiffer: MySQL, PostgreSQL, SQLite, SQL Server, Oracle primary-key metadata equivalence
- Integration suite: create V1 table, sync V2 with added ge, run second sync for idempotency, assert ge exists and id remains primary key
- Suite is attached to MySQL, PostgreSQL, SQLite, SQL Server, and Oracle integration tests

## Local verification
- ./gradlew.bat :kronos-core:test --tests com.kotlinorm.orm.ddl.TableOperationUtilTest --no-daemon --console=plain
- ./gradlew.bat :kronos-testing:test --tests com.kotlinorm.integration.SqliteSchemaSyncRegressionTest --no-daemon --console=plain

Note: Docker Desktop installation via winget did not complete in this Windows session, so non-SQLite database integration runs are left to CI.