### PR TITLE
fix(docs): unify language switcher

### DIFF
--- a/kronos-docs/src/app/components/language-switch/language-switch.component.css
+++ b/kronos-docs/src/app/components/language-switch/language-switch.component.css
@@ -1,0 +1,62 @@
+:host {
+    display: inline-flex;
+    --kronos-language-bg: rgba(255, 255, 255, 0.72);
+    --kronos-language-border: rgba(15, 23, 42, 0.14);
+    --kronos-language-text: #0f172a;
+    --kronos-language-hover-border: rgba(55, 183, 128, 0.55);
+    --kronos-language-hover-bg: rgba(55, 183, 128, 0.12);
+    --kronos-language-hover-text: #0f172a;
+    --kronos-language-active-bg: rgba(223, 255, 103, 0.28);
+    --kronos-language-active-text: #0f172a;
+    --kronos-language-accent: #5b7f00;
+    --kronos-language-muted: rgba(15, 23, 42, 0.56);
+}
+
+:host-context(.dark),
+:host-context([data-theme="dark"]) {
+    --kronos-language-bg: rgba(255, 255, 255, 0.04);
+    --kronos-language-border: rgba(246, 247, 239, 0.16);
+    --kronos-language-text: #f6f7ef;
+    --kronos-language-hover-border: rgba(93, 253, 194, 0.65);
+    --kronos-language-hover-bg: rgba(93, 253, 194, 0.12);
+    --kronos-language-hover-text: #ffffff;
+    --kronos-language-active-bg: rgba(223, 255, 103, 0.14);
+    --kronos-language-active-text: #faffd7;
+    --kronos-language-accent: #dfff67;
+    --kronos-language-muted: rgba(246, 247, 239, 0.58);
+}
+
+.kronos-language-trigger {
+    box-sizing: border-box;
+    appearance: none;
+    -webkit-appearance: none;
+    display: inline-flex;
+    width: 7.25rem;
+    min-height: 2.6rem;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    padding: 0;
+    border: 1px solid var(--kronos-language-border);
+    border-radius: 4px;
+    background: var(--kronos-language-bg);
+    color: var(--kronos-language-text);
+    font: inherit;
+    font-size: 0.88rem;
+    font-weight: 600;
+    line-height: 1;
+    text-decoration: none;
+    cursor: pointer;
+    transition: border-color 180ms ease, background 180ms ease, color 180ms ease;
+}
+
+.kronos-language-trigger:hover,
+.kronos-language-trigger[aria-expanded="true"] {
+    border-color: var(--kronos-language-hover-border);
+    background: var(--kronos-language-hover-bg);
+    color: var(--kronos-language-hover-text);
+}
+
+.kronos-language-trigger .pi {
+    font-size: 0.7rem;
+}

--- a/kronos-docs/src/app/components/language-switch/language-switch.component.html
+++ b/kronos-docs/src/app/components/language-switch/language-switch.component.html
@@ -1,0 +1,24 @@
+<button
+        type="button"
+        class="kronos-language-trigger"
+        aria-label="Change language"
+        (click)="languagePopover.toggle($event)">
+    <span>{{ label }}</span>
+    <span class="pi pi-chevron-down" aria-hidden="true"></span>
+</button>
+
+<p-popover #languagePopover class="m-0 p-0" styleClass="kronos-language-popover" [appendTo]="appendTo">
+    <ul class="kronos-language-list" aria-label="Language options">
+        @for (item of languages; track item.lang) {
+            <li>
+                <button
+                        type="button"
+                        class="kronos-language-option"
+                        [class.active]="language === item.lang"
+                        (click)="setLanguage(item.lang); languagePopover.hide()">
+                    <span class="kronos-language-label">{{ item.label }}</span>
+                </button>
+            </li>
+        }
+    </ul>
+</p-popover>

--- a/kronos-docs/src/app/components/language-switch/language-switch.component.ts
+++ b/kronos-docs/src/app/components/language-switch/language-switch.component.ts
@@ -1,0 +1,61 @@
+import {CommonModule} from '@angular/common';
+import {Component, Input} from '@angular/core';
+import {Router} from '@angular/router';
+import {TranslocoService} from '@jsverse/transloco';
+import {Popover} from 'primeng/popover';
+import {AppService} from '../../app.service';
+
+type LanguageCode = 'zh-CN' | 'en';
+
+type LanguageOption = {
+    lang: LanguageCode;
+    label: string;
+};
+
+@Component({
+    selector: 'kronos-language-switch',
+    standalone: true,
+    imports: [
+        CommonModule,
+        Popover
+    ],
+    templateUrl: './language-switch.component.html',
+    styleUrl: './language-switch.component.css'
+})
+export class LanguageSwitchComponent {
+    @Input() appendTo: HTMLElement | string | null = null;
+
+    readonly languages: LanguageOption[] = [
+        {lang: 'zh-CN', label: '简体中文'},
+        {lang: 'en', label: 'English'}
+    ];
+
+    constructor(
+        private appService: AppService,
+        private translocoService: TranslocoService,
+        private router: Router
+    ) {
+    }
+
+    get language(): LanguageCode {
+        return this.appService.language === 'zh-CN' ? 'zh-CN' : 'en';
+    }
+
+    get label(): string {
+        return this.languages.find(item => item.lang === this.language)?.label ?? 'English';
+    }
+
+    setLanguage(language: LanguageCode): void {
+        if (this.language === language) {
+            return;
+        }
+
+        this.appService.language = language;
+        this.translocoService.setActiveLang(language);
+
+        if (this.router.url.startsWith('/documentation/')) {
+            const docPath = this.router.url.split('/').slice(3).join('/') || 'getting-started/introduce';
+            void this.router.navigate([`/documentation/${language}/${docPath}`]);
+        }
+    }
+}

--- a/kronos-docs/src/app/routes/documentation/documentation.component.css
+++ b/kronos-docs/src/app/routes/documentation/documentation.component.css
@@ -187,6 +187,11 @@
   align-items: center;
 }
 
+:host ::ng-deep ng-doc-navbar .ng-doc-navbar-right {
+  display: flex;
+  gap: 0.75rem;
+}
+
 :host ::ng-deep ng-doc-navbar,
 :host ::ng-deep .ng-doc-navbar {
   display: flex !important;
@@ -801,8 +806,8 @@
 }
 
 :host ::ng-deep {
-  --p-popover-background: var(--ng-doc-navbar-background) !important;
-  --p-popover-border-color: var(--ng-doc-navbar-background) !important;
+  --p-popover-background: var(--kronos-doc-surface) !important;
+  --p-popover-border-color: var(--kronos-doc-rule) !important;
 }
 
 /* 侧边栏收缩 */
@@ -826,11 +831,6 @@
 
 :host ::ng-deep .ng-doc-sidenav-content {
   transition: margin-left 0.3s ease, width 0.3s ease;
-}
-
-/* 语言切换文本颜色 */
-.lang-text {
-  color: var(--ng-doc-text);
 }
 
 /* 文档页脚 */

--- a/kronos-docs/src/app/routes/documentation/documentation.component.html
+++ b/kronos-docs/src/app/routes/documentation/documentation.component.html
@@ -27,12 +27,7 @@
         </div>
         <div ngDocNavbarRight>
             <div class="ng-doc-header-controls">
-                <a ng-doc-button-icon
-                   ngDocTooltip="change language"
-                   size="large"
-                   (click)="op.toggle($event)">
-                    <ng-doc-icon [size]="24" customIcon="language"></ng-doc-icon>
-                </a>
+                <kronos-language-switch [appendTo]="elementRef.nativeElement"/>
                 <ng-doc-theme-toggle></ng-doc-theme-toggle>
                 <a
                         href="https://github.com/Kronos-orm/Kronos-orm"
@@ -43,20 +38,6 @@
                     <ng-doc-icon [size]="24" customIcon="github"></ng-doc-icon>
                 </a>
             </div>
-
-            <p-popover #op class="m-0 p-0" [appendTo]="elementRef.nativeElement">
-                <ul class="list-none m-0 p-0 w-48">
-                    @for (item of [{lang: 'zh-CN', label: '简体中文'}, {lang: 'en', label: 'English'}];track $index) {
-                        <a class="p-2 rounded-border hover:bg-emphasis hover:bg-surface-100! w-full cursor-pointer flex"
-                           (click)="setLang(item.lang)">
-                            <span class="font-bold flex-1 lang-text">{{ item.label }}</span>
-                            <span class="ml-2 flex-1 text-right lang-text">
-                                <span class="pi pi-globe"></span>
-                            </span>
-                        </a>
-                    }
-                </ul>
-            </p-popover>
         </div>
     </ng-doc-navbar>
     <kronos-ng-doc-sidebar ngDocCustomSidebar/>

--- a/kronos-docs/src/app/routes/documentation/documentation.component.ts
+++ b/kronos-docs/src/app/routes/documentation/documentation.component.ts
@@ -8,11 +8,11 @@ import {NgDocThemeToggleComponent} from "@ng-doc/app";
 import {NgDocThemeService} from "@ng-doc/app/services/theme";
 import {NgDocButtonIconComponent, NgDocIconComponent, NgDocTooltipDirective} from "@ng-doc/ui-kit";
 import {WikiComponent} from "../../components/wiki.component";
-import {Popover} from "primeng/popover";
 import {takeUntilDestroyed} from "@angular/core/rxjs-interop";
 import {filter} from "rxjs";
 import TurndownService from 'turndown';
 import {gfm} from 'turndown-plugin-gfm';
+import {LanguageSwitchComponent} from "../../components/language-switch/language-switch.component";
 
 @Component({
     selector: 'app-documentation',
@@ -26,7 +26,7 @@ import {gfm} from 'turndown-plugin-gfm';
         NgDocTooltipDirective,
         WikiComponent,
         RouterLink,
-        Popover
+        LanguageSwitchComponent
     ],
     templateUrl: './documentation.component.html',
     styleUrl: './documentation.component.css'
@@ -80,10 +80,6 @@ export class DocumentationComponent implements OnDestroy {
         // Restore dark class when leaving documentation, since all other pages are always dark
         document.documentElement.classList.add('dark');
         this.copyObserver?.disconnect();
-    }
-
-    get language(): string {
-        return this.appService.language;
     }
 
     private applyDarkClass(theme: string | null) {
@@ -151,10 +147,4 @@ export class DocumentationComponent implements OnDestroy {
         this.copyObserver.observe(document.body, {childList: true, subtree: true});
     }
 
-    async setLang(lang: string) {
-        this.appService.language = lang; // update language
-        this.translocoService.setActiveLang(lang);
-        const newUrl = `/documentation/${lang}/${this.router.url.split("/").slice(3).join("/")}`;
-        await this.router.navigate([newUrl]);
-    }
 }

--- a/kronos-docs/src/app/routes/home/home.component.css
+++ b/kronos-docs/src/app/routes/home/home.component.css
@@ -108,7 +108,6 @@ a {
     gap: 0.5rem;
 }
 
-.language-button,
 .nav-cta,
 .action {
     display: inline-flex;
@@ -124,11 +123,6 @@ a {
     transition: border-color 220ms ease, background 220ms ease, color 220ms ease;
 }
 
-.language-button {
-    width: 3.25rem;
-}
-
-.language-button.active,
 .nav-cta {
     border-color: rgba(223, 255, 103, 0.5);
     background: rgba(223, 255, 103, 0.12);
@@ -137,8 +131,10 @@ a {
 
 .nav-cta {
     position: relative;
+    width: 7.25rem;
     padding: 0 1.1rem;
     overflow: hidden;
+    white-space: nowrap;
 }
 
 .hero-section {
@@ -266,7 +262,6 @@ em {
 }
 
 .action-secondary:hover,
-.language-button:hover,
 .nav-cta:hover {
     border-color: rgba(93, 253, 194, 0.65);
     background: rgba(93, 253, 194, 0.12);

--- a/kronos-docs/src/app/routes/home/home.component.html
+++ b/kronos-docs/src/app/routes/home/home.component.html
@@ -18,12 +18,7 @@
         </div>
 
         <div class="nav-actions">
-            <button type="button"
-                    class="language-button"
-                    [class.active]="language === 'zh-CN'"
-                    (click)="setLanguage(language === 'zh-CN' ? 'en' : 'zh-CN')">
-                {{ language === 'zh-CN' ? '中文' : 'EN' }}
-            </button>
+            <kronos-language-switch/>
             <a class="nav-cta" [routerLink]="docsUrl">{{ isZh ? '打开文档' : 'Open docs' }}</a>
         </div>
     </nav>

--- a/kronos-docs/src/app/routes/home/home.component.ts
+++ b/kronos-docs/src/app/routes/home/home.component.ts
@@ -2,6 +2,7 @@ import {CommonModule} from '@angular/common';
 import {Component, OnDestroy, OnInit} from '@angular/core';
 import {RouterLink} from '@angular/router';
 import {AppService} from '../../app.service';
+import {LanguageSwitchComponent} from '../../components/language-switch/language-switch.component';
 
 type LocalizedText = {
     zh: string;
@@ -60,7 +61,7 @@ const KEYWORDS = new Set([
 @Component({
   selector: 'app-home',
   standalone: true,
-  imports: [CommonModule, RouterLink],
+  imports: [CommonModule, RouterLink, LanguageSwitchComponent],
   templateUrl: './home.component.html',
   styleUrl: './home.component.css'
 })
@@ -451,10 +452,6 @@ export class HomeComponent implements OnInit, OnDestroy {
 
     get isZh(): boolean {
         return this.language === 'zh-CN';
-    }
-
-    setLanguage(language: string): void {
-        this.appService.language = language;
     }
 
     setStage(index: number): void {

--- a/kronos-docs/src/styles.css
+++ b/kronos-docs/src/styles.css
@@ -40,11 +40,29 @@ h1, h2, h3, h4, h5, h6 {
     --p-menu-background: var(--ng-doc-sidebar-background) !important;
     --p-menu-item-color: var(--ng-doc-text) !important;
     --p-megamenu-item-active-background: rgba(127, 82, 255, 0.15) !important;
+    --kronos-language-bg: rgba(255, 255, 255, 0.72);
+    --kronos-language-border: rgba(15, 23, 42, 0.14);
+    --kronos-language-text: #0f172a;
+    --kronos-language-hover-border: rgba(55, 183, 128, 0.55);
+    --kronos-language-hover-bg: rgba(55, 183, 128, 0.12);
+    --kronos-language-hover-text: #0f172a;
+    --kronos-language-active-bg: rgba(223, 255, 103, 0.28);
+    --kronos-language-active-text: #0f172a;
+    --kronos-language-accent: #5b7f00;
 }
 
 :root.dark,
 .dark {
     --ng-doc-mermaid-viewer-background: #080909;
+    --kronos-language-bg: rgba(255, 255, 255, 0.04);
+    --kronos-language-border: rgba(246, 247, 239, 0.16);
+    --kronos-language-text: #f6f7ef;
+    --kronos-language-hover-border: rgba(93, 253, 194, 0.65);
+    --kronos-language-hover-bg: rgba(93, 253, 194, 0.12);
+    --kronos-language-hover-text: #ffffff;
+    --kronos-language-active-bg: rgba(223, 255, 103, 0.14);
+    --kronos-language-active-text: #faffd7;
+    --kronos-language-accent: #dfff67;
 }
 
 .dark .ng-doc-mermaid-viewer,
@@ -56,6 +74,69 @@ h1, h2, h3, h4, h5, h6 {
 img {
     user-drag: none;
     -webkit-user-drag: none;
+}
+
+.kronos-language-popover .kronos-language-list {
+    width: 12rem;
+    margin: 0;
+    padding: 0.35rem;
+    list-style: none;
+}
+
+.kronos-language-popover .kronos-language-list li {
+    margin: 0;
+    padding: 0;
+}
+
+.kronos-language-popover .kronos-language-option {
+    position: relative;
+    box-sizing: border-box;
+    appearance: none;
+    -webkit-appearance: none;
+    display: flex;
+    width: 100%;
+    min-height: 2.5rem;
+    align-items: center;
+    padding: 0 0.75rem 0 0.9rem;
+    border: 0;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--kronos-language-text);
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition: background 160ms ease, color 160ms ease;
+}
+
+.kronos-language-popover .kronos-language-option::before {
+    content: "";
+    position: absolute;
+    left: 0.35rem;
+    top: 0.55rem;
+    bottom: 0.55rem;
+    width: 0.14rem;
+    border-radius: 999px;
+    background: transparent;
+}
+
+.kronos-language-popover .kronos-language-option:hover {
+    background: var(--kronos-language-hover-bg);
+    color: var(--kronos-language-hover-text);
+}
+
+.kronos-language-popover .kronos-language-option.active {
+    background: var(--kronos-language-active-bg);
+    color: var(--kronos-language-active-text);
+}
+
+.kronos-language-popover .kronos-language-option.active::before,
+.kronos-language-popover .kronos-language-option:hover::before {
+    background: var(--kronos-language-accent);
+}
+
+.kronos-language-popover .kronos-language-label {
+    color: currentColor;
+    font-weight: 600;
 }
 
 ::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- Share one language switcher component between the home and documentation pages.
- Use a dropdown on both pages with localized labels and green hover/active states.
- Remove the documentation page's old language popover markup.

## Verification
- Manually verified by maintainer.