### PR TITLE
fix(docs): restore docs theme details

### DIFF
--- a/kronos-docs/src/app/components/language-switch/language-switch.component.css
+++ b/kronos-docs/src/app/components/language-switch/language-switch.component.css
@@ -3,12 +3,12 @@
     --kronos-language-bg: rgba(255, 255, 255, 0.72);
     --kronos-language-border: rgba(15, 23, 42, 0.14);
     --kronos-language-text: #0f172a;
-    --kronos-language-hover-border: rgba(55, 183, 128, 0.55);
-    --kronos-language-hover-bg: rgba(55, 183, 128, 0.12);
+    --kronos-language-hover-border: rgba(37, 99, 235, 0.45);
+    --kronos-language-hover-bg: rgba(37, 99, 235, 0.08);
     --kronos-language-hover-text: #0f172a;
-    --kronos-language-active-bg: rgba(223, 255, 103, 0.28);
+    --kronos-language-active-bg: rgba(37, 99, 235, 0.12);
     --kronos-language-active-text: #0f172a;
-    --kronos-language-accent: #5b7f00;
+    --kronos-language-accent: #2563eb;
     --kronos-language-muted: rgba(15, 23, 42, 0.56);
 }
 

--- a/kronos-docs/src/app/docs/en/8.resources/idea-plugin/index.md
+++ b/kronos-docs/src/app/docs/en/8.resources/idea-plugin/index.md
@@ -665,9 +665,11 @@ Use these checks when Gradle or Maven succeeds but IDEA does not show Kronos com
 
 | Symptom | Check | Fix |
 |---------|-------|-----|
-| `toDataMap()` or `__tableName` behaves like the default `KPojo` body | The source set was not compiled with Kronos support | Enable {{ $.keyword("configuration/compiler-plugins", ["Compiler Plugins"]) }} and reimport the project |
+| `toDataMap()` or `__tableName` behaves like the default `KPojo` body | The source set was not compiled with Kronos support | Enable compiler plugin support and reimport the project |
 | Projection aliases such as `nameLength` are missing | The IDEA plugin was installed before the project import completed | Reload Gradle/Maven and reopen the Kotlin file |
 | Diagnostics are visible in build output but not in the editor | IDEA is using an incompatible Kotlin plugin or stale project model | Update IDEA/Kotlin plugin to a Kotlin 2.4.0-compatible build and invalidate caches if needed |
 | Codegen UI cannot find data source settings | The config path does not point to the intended JSON file | Set `Config File` on `Kronos ORM Setting` |
+
+Compiler plugin setup is covered in {{ $.keyword("configuration/compiler-plugins", ["Compiler Plugins"]) }}.
 
 For more query, subquery, and INSERT SELECT rules, see {{ $.keyword("query/subqueries", ["Subqueries"]) }}. For setup problems, see {{ $.keyword("resources/troubleshooting", ["Troubleshooting"]) }}.

--- a/kronos-docs/src/app/docs/zh-CN/8.resources/idea-plugin/index.md
+++ b/kronos-docs/src/app/docs/zh-CN/8.resources/idea-plugin/index.md
@@ -665,9 +665,11 @@ IDEA 插件会把这些 Kronos DSL 规则直接显示在编辑器中：
 
 | 现象 | 检查点 | 修复方式 |
 |------|--------|----------|
-| `toDataMap()` 或 `__tableName` 表现为默认 `KPojo` 方法 | source set 没有经过 Kronos 编译期支持 | 启用 {{ $.keyword("configuration/compiler-plugins", ["编译器插件"]) }} 后重新导入项目 |
+| `toDataMap()` 或 `__tableName` 表现为默认 `KPojo` 方法 | source set 没有经过 Kronos 编译期支持 | 启用编译器插件后重新导入项目 |
 | `nameLength` 这类投影 alias 没有补全 | 项目导入完成前已安装插件，IDE 模型较旧 | 重新加载 Gradle/Maven，并重新打开 Kotlin 文件 |
 | 构建输出有诊断，但编辑器没有提示 | IDEA 使用的 Kotlin 插件或项目模型不匹配 | 更新到支持 Kotlin 2.4.0 的 IDEA/Kotlin 插件，必要时清理缓存 |
 | Codegen UI 找不到数据源配置 | 配置路径没有指向目标 JSON 文件 | 在 `Kronos ORM Setting` 中设置 `Config File` |
+
+编译器插件配置见 {{ $.keyword("configuration/compiler-plugins", ["编译器插件"]) }}。
 
 更多查询、子查询和 INSERT SELECT 规则见 {{ $.keyword("query/subqueries", ["子查询"]) }}。安装与运行问题见 {{ $.keyword("resources/troubleshooting", ["故障排查"]) }}。

--- a/kronos-docs/src/app/routes/documentation/documentation.component.css
+++ b/kronos-docs/src/app/routes/documentation/documentation.component.css
@@ -599,8 +599,11 @@
 }
 
 :host ::ng-deep .ng-doc-code-body pre code .line.highlighted {
+  display: block;
   min-width: 100% !important;
   width: max-content !important;
+  background: var(--kronos-doc-code-highlight) !important;
+  box-shadow: inset 3px 0 0 var(--kronos-doc-primary);
 }
 
 :host ::ng-deep li.ngde::marker {

--- a/kronos-docs/src/styles.css
+++ b/kronos-docs/src/styles.css
@@ -43,12 +43,12 @@ h1, h2, h3, h4, h5, h6 {
     --kronos-language-bg: rgba(255, 255, 255, 0.72);
     --kronos-language-border: rgba(15, 23, 42, 0.14);
     --kronos-language-text: #0f172a;
-    --kronos-language-hover-border: rgba(55, 183, 128, 0.55);
-    --kronos-language-hover-bg: rgba(55, 183, 128, 0.12);
+    --kronos-language-hover-border: rgba(37, 99, 235, 0.45);
+    --kronos-language-hover-bg: rgba(37, 99, 235, 0.08);
     --kronos-language-hover-text: #0f172a;
-    --kronos-language-active-bg: rgba(223, 255, 103, 0.28);
+    --kronos-language-active-bg: rgba(37, 99, 235, 0.12);
     --kronos-language-active-text: #0f172a;
-    --kronos-language-accent: #5b7f00;
+    --kronos-language-accent: #2563eb;
 }
 
 :root.dark,


### PR DESCRIPTION
## Summary
- restore full-line background for highlighted code lines
- align the language switcher light theme with the docs blue theme
- move IDEA plugin troubleshooting macro links out of Markdown tables in zh-CN and en docs

## Verification
- git diff --check